### PR TITLE
Added basic DIV operator

### DIFF
--- a/dainemo/autograd/ops/basics.mojo
+++ b/dainemo/autograd/ops/basics.mojo
@@ -120,7 +120,7 @@ struct DIV:
         """Backward operation of element wise division."""
         alias nelts: Int = simdwidthof[dtype]()
         # d(x/y) / dx = 1/y
-        # d(x/y) / dy = x/y^2
+        # d(x/y) / dy = -x/y^2
         if tensor_id == 0:
             let n2 = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[1])]
             let res = elwise_op[dtype, nelts, div](1.0, n2.tensor)
@@ -129,7 +129,8 @@ struct DIV:
             let n1 = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])]
             let n2 = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[1])]
             let n2_sq = elwise_pow[dtype, nelts](n2.tensor, 2)
-            let res = elwise_op[dtype, nelts, div](n1.tensor, n2_sq)
+            let div_n1_n2_sq = elwise_op[dtype, nelts, div](n1.tensor, n2_sq)
+            let res = elwise_op[dtype, nelts, mul](div_n1_n2_sq, -1.0)
             return elwise_op[dtype, nelts, mul](res, ug)
 
 

--- a/dainemo/autograd/ops/basics.mojo
+++ b/dainemo/autograd/ops/basics.mojo
@@ -92,7 +92,45 @@ struct MUL:
 
 
 # <------------DIV------------>
-# TODO
+struct DIV:
+    @staticmethod
+    fn forward(n1: Node[dtype], n2: Node[dtype]) -> Node[dtype]:
+        """Forward operation of element wise division."""
+        alias nelts: Int = simdwidthof[dtype]()
+        let res: Tensor[dtype]
+        if n1.tensor.shape() == n2.tensor.shape():
+            res = elwise_op[dtype, nelts, div](n1.tensor, n2.tensor)
+        else:
+            res = batch_tensor_elwise_op[dtype, nelts, div](n1.tensor, n2.tensor)
+        return GRAPH.create_graph_node[Self.backward](res, n1, n2)
+
+    @staticmethod
+    fn forward(n1: Node[dtype], a: SIMD[dtype, 1]) -> Node[dtype]:
+         """Forward operation of tensor-scalar division."""
+        alias nelts: Int = simdwidthof[dtype]()
+        let res: Tensor[dtype] = elwise_op[dtype, nelts, div](n1.tensor, a)
+        var a_tensor: Tensor[dtype] = Tensor[dtype](1)
+        a_tensor[0] = a
+        return GRAPH.create_graph_node[Self.backward](res, n1, Node[dtype](a_tensor))
+
+    @staticmethod
+    fn backward(
+        ug: Tensor[dtype], tensor_vec: DynamicVector[String], tensor_id: Int
+    ) -> Tensor[dtype]:
+        """Backward operation of element wise division."""
+        alias nelts: Int = simdwidthof[dtype]()
+        # d(x/y) / dx = 1/y
+        # d(x/y) / dy = x/y^2
+        if tensor_id == 0:
+            let n2 = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[1])]
+            let res = elwise_op[dtype, nelts, div](1.0, n2.tensor)
+            return elwise_op[dtype, nelts, mul](res, ug)
+        else:
+            let n1 = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])]
+            let n2 = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[1])]
+            let n2_sq = elwise_pow[dtype, nelts](n2.tensor, 2)
+            let res = elwise_op[dtype, nelts, div](n1.tensor, n2_sq)
+            return elwise_op[dtype, nelts, mul](res, ug)
 
 
 # <------------DOT------------>

--- a/test/test_backward.mojo
+++ b/test/test_backward.mojo
@@ -107,7 +107,7 @@ fn test_DIV() raises:
     var expected_ug1 = Tensor[dtype](2, 3)
     fill[dtype, nelts](expected_ug1, 1.0 / 2.0)
     var expected_ug2 = Tensor[dtype](2, 3)
-    fill[dtype, nelts](expected_ug2, 1.0 / (2.0**2))
+    fill[dtype, nelts](expected_ug2, -1.0 / (2.0**2))
 
     assert_tensors_equal(ug1, expected_ug1)
     assert_tensors_equal(ug2, expected_ug2)

--- a/test/test_ops.mojo
+++ b/test/test_ops.mojo
@@ -4,10 +4,10 @@ from testing import assert_equal
 from test_tensorutils import assert_tensors_equal
 
 from dainemo import GRAPH
-from dainemo.autograd.ops.basics import ADD, SUB, DOT, SUM, MUL, POW
+from dainemo.autograd.ops.basics import ADD, SUB, DOT, SUM, MUL, POW, DIV
 from dainemo.utils.tensorutils import fill
 
-alias dtype = DType.float32 
+alias dtype = DType.float32
 alias nelts: Int = simdwidthof[dtype]()
 
 
@@ -19,12 +19,13 @@ fn test_ADD() raises:
     fill[dtype, nelts](t2, 1.0)
 
     let res = ADD.forward(t1, t2)
-    
+
     var expected = Tensor[dtype](2, 3)
     fill[dtype, nelts](expected, 2.0)
     assert_tensors_equal(res.tensor, expected)
     assert_equal(GRAPH.graph.size, 3)
     GRAPH.reset()
+
 
 # <------------SUB------------>
 fn test_SUB() raises:
@@ -34,7 +35,7 @@ fn test_SUB() raises:
     fill[dtype, nelts](t2, 1.0)
 
     let res = SUB.forward(t1, t2)
-    
+
     let expected = Tensor[dtype](2, 3)
     assert_tensors_equal(res.tensor, expected)
     assert_equal(GRAPH.graph.size, 3)
@@ -49,7 +50,7 @@ fn test_MUL() raises:
     fill[dtype, nelts](t2, 1.0)
 
     var res = MUL.forward(t1, t2)
-    
+
     var expected = Tensor[dtype](2, 3)
     fill[dtype, nelts](expected, 1.0)
     assert_tensors_equal(res.tensor, expected)
@@ -58,6 +59,28 @@ fn test_MUL() raises:
 
     res = MUL.forward(t1, 5)
     fill[dtype, nelts](expected, 5)
+    assert_tensors_equal(res.tensor, expected)
+    assert_equal(GRAPH.graph.size, 3)
+    GRAPH.reset()
+
+
+# <------------DIV------------>
+fn test_DIV() raises:
+    var t1: Tensor[dtype] = Tensor[dtype](2, 3)
+    var t2: Tensor[dtype] = Tensor[dtype](2, 3)
+    fill[dtype, nelts](t1, 1.0)
+    fill[dtype, nelts](t2, 3.0)
+
+    var res = DIV.forward(t1, t2)
+
+    var expected = Tensor[dtype](2, 3)
+    fill[dtype, nelts](expected, 1.0 / 3.0)
+    assert_tensors_equal(res.tensor, expected)
+    assert_equal(GRAPH.graph.size, 3)
+    GRAPH.reset()
+
+    res = DIV.forward(t1, 5)
+    fill[dtype, nelts](expected, 1.0 / 5.0)
     assert_tensors_equal(res.tensor, expected)
     assert_equal(GRAPH.graph.size, 3)
     GRAPH.reset()
@@ -124,11 +147,11 @@ fn test_SUM() raises:
 
 
 fn main():
-    
     try:
         test_ADD()
         test_SUB()
         test_MUL()
+        test_DIV()
         test_DOT()
         test_POW()
         test_SUM()


### PR DESCRIPTION
Added basic DIV operator and its tests for forward and backward.

**Extra:**
- An Idea: Maybe we could add to the NODE struct or (maybe another struct, I don't know how you would want to implement it) operator overloading to add the ability to be able to do `input / weights` instead of `DIV.forward(inputs, weights)`
- Also maybe in the *future*, if its possible, maybe it would be better to also have a graph of the forward operations, instead of doing them the moment the function is called (like `input / weight` doesn't do the division but instead adds the division operation to the forward graph and then we execute it later when necessary), to be able to do fusion operations and to be able to not have to create new memory of a tensor for each result (so to also be able to have lazy initialization of memory)