### PR TITLE
Added vectorization to transpose_2d and created a transpose function for any rank with vectorization

### DIFF
--- a/dainemo/utils/tensorutils.mojo
+++ b/dainemo/utils/tensorutils.mojo
@@ -16,15 +16,22 @@ fn fill[dtype: DType, nelts: Int](inout t: Tensor[dtype], val: SIMD[dtype, 1]):
     @parameter
     fn fill_vec[nelts: Int](idx: Int):
         t.simd_store[nelts](idx, t.simd_load[nelts](idx).splat(val))
+
     vectorize[nelts, fill_vec](t.num_elements())
 
 
 @always_inline
-fn elwise_transform[dtype: DType, nelts: Int, func: fn[dtype: DType, nelts: Int](x: SIMD[dtype, nelts]) -> SIMD[dtype, nelts]](t: Tensor[dtype]) -> Tensor[dtype]:
+fn elwise_transform[
+    dtype: DType,
+    nelts: Int,
+    func: fn[dtype: DType, nelts: Int] (x: SIMD[dtype, nelts]) -> SIMD[dtype, nelts],
+](t: Tensor[dtype]) -> Tensor[dtype]:
     var t_new = Tensor[dtype](t.shape())
+
     @parameter
     fn vecmath[nelts: Int](idx: Int):
         t_new.simd_store[nelts](idx, func[dtype, nelts](t.simd_load[nelts](idx)))
+
     vectorize[nelts, vecmath](t.num_elements())
     return t_new
 
@@ -32,31 +39,51 @@ fn elwise_transform[dtype: DType, nelts: Int, func: fn[dtype: DType, nelts: Int]
 @always_inline
 fn elwise_pow[dtype: DType, nelts: Int](t: Tensor[dtype], x: Int) -> Tensor[dtype]:
     var t_new = Tensor[dtype](t.shape())
+
     @parameter
     fn vecpow[nelts: Int](idx: Int):
         t_new.simd_store[nelts](idx, pow(t.simd_load[nelts](idx), x))
+
     vectorize[nelts, vecpow](t.num_elements())
     return t_new
 
 
 @always_inline
-fn elwise_op[dtype: DType, nelts: Int, func: fn[dtype: DType, nelts: Int](x: SIMD[dtype, nelts], y: SIMD[dtype, nelts]) -> SIMD[dtype, nelts]](t1: Tensor[dtype], t2: Tensor[dtype]) -> Tensor[dtype]:
-    '''Element-wise operation on two tensors.'''
+fn elwise_op[
+    dtype: DType,
+    nelts: Int,
+    func: fn[dtype: DType, nelts: Int] (
+        x: SIMD[dtype, nelts], y: SIMD[dtype, nelts]
+    ) -> SIMD[dtype, nelts],
+](t1: Tensor[dtype], t2: Tensor[dtype]) -> Tensor[dtype]:
+    """Element-wise operation on two tensors."""
     var t_new = Tensor[dtype](t1.shape())
+
     @parameter
     fn vecmath[nelts: Int](idx: Int):
-        t_new.simd_store[nelts](idx, func[dtype, nelts](t1.simd_load[nelts](idx), t2.simd_load[nelts](idx)))
+        t_new.simd_store[nelts](
+            idx, func[dtype, nelts](t1.simd_load[nelts](idx), t2.simd_load[nelts](idx))
+        )
+
     vectorize[nelts, vecmath](t1.num_elements())
     return t_new
 
 
 @always_inline
-fn elwise_op[dtype: DType, nelts: Int, func: fn[dtype: DType, nelts: Int](x: SIMD[dtype, nelts], y: SIMD[dtype, nelts]) -> SIMD[dtype, nelts]](t1: Tensor[dtype], a: SIMD[dtype, 1]) -> Tensor[dtype]:
-    '''Element-wise operation on a tensor and a scalar.'''
+fn elwise_op[
+    dtype: DType,
+    nelts: Int,
+    func: fn[dtype: DType, nelts: Int] (
+        x: SIMD[dtype, nelts], y: SIMD[dtype, nelts]
+    ) -> SIMD[dtype, nelts],
+](t1: Tensor[dtype], a: SIMD[dtype, 1]) -> Tensor[dtype]:
+    """Element-wise operation on a tensor and a scalar."""
     var t_new = Tensor[dtype](t1.shape())
+
     @parameter
     fn vecmath[nelts: Int](idx: Int):
         t_new.simd_store[nelts](idx, func[dtype, nelts](t1.simd_load[nelts](idx), a))
+
     vectorize[nelts, vecmath](t1.num_elements())
     return t_new
 
@@ -81,19 +108,28 @@ fn elwise_op[
 
 
 @always_inline
-fn batch_tensor_elwise_op[dtype: DType, nelts: Int, func: fn[dtype: DType, nelts: Int](x: SIMD[dtype, nelts], y: SIMD[dtype, nelts]) -> SIMD[dtype, nelts]](t_batch: Tensor[dtype], t2: Tensor[dtype]) -> Tensor[dtype]:
-    '''Element-wise operation on between a batch of tensors t_batch and a tensor t2.'''
+fn batch_tensor_elwise_op[
+    dtype: DType,
+    nelts: Int,
+    func: fn[dtype: DType, nelts: Int] (
+        x: SIMD[dtype, nelts], y: SIMD[dtype, nelts]
+    ) -> SIMD[dtype, nelts],
+](t_batch: Tensor[dtype], t2: Tensor[dtype]) -> Tensor[dtype]:
+    """Element-wise operation on between a batch of tensors t_batch and a tensor t2."""
     var t_new = Tensor[dtype](t_batch.shape())
 
     @parameter
     fn row_op(r: Int):
-
         @parameter
         fn vecmath[nelts: Int](c: Int):
             t_new.simd_store[nelts](
-                    r * t_batch.dim(1) + c, 
-                    func[dtype, nelts](t_batch.simd_load[nelts](r * t_batch.dim(1) + c), t2.simd_load[nelts](c))
-                )
+                r * t_batch.dim(1) + c,
+                func[dtype, nelts](
+                    t_batch.simd_load[nelts](r * t_batch.dim(1) + c),
+                    t2.simd_load[nelts](c),
+                ),
+            )
+
         vectorize[nelts, vecmath](t_batch.dim(1))
 
     parallelize[row_op](t_batch.dim(0), t_batch.dim(0))
@@ -103,27 +139,30 @@ fn batch_tensor_elwise_op[dtype: DType, nelts: Int, func: fn[dtype: DType, nelts
 @always_inline
 fn tsum[dtype: DType, nelts: Int](t: Tensor[dtype]) -> SIMD[dtype, 1]:
     var s: SIMD[dtype, 1] = 0
+
     @parameter
     fn vecsum[nelts: Int](idx: Int):
         s += t.simd_load[nelts](idx).reduce_add()
+
     vectorize[nelts, vecsum](t.num_elements())
     return s
+
 
 # from testing import assert_equal
 @always_inline
 fn tsum[dtype: DType, nelts: Int](t: Tensor[dtype], axis: Int) -> Tensor[dtype]:
-    
     let d: Int = 1 if axis == 0 else 0
     let t_new = Tensor[dtype](1, t.dim(d)) if axis == 0 else Tensor[dtype](t.dim(d), 1)
 
     @parameter
     fn parallel_sum(i: Int):
-
         var s: SIMD[dtype, 1] = 0
+
         @parameter
         fn axissum[nelts: Int](j: Int):
             let index = j * t.dim(d) + i if axis == 0 else i * t.dim(axis) + j
             s += t.simd_load[nelts](index).reduce_add()
+
         vectorize[nelts, axissum](t.dim(axis))
         t_new[i] = s
 
@@ -141,24 +180,25 @@ fn tmean[dtype: DType, nelts: Int](t: Tensor[dtype]) -> SIMD[dtype, 1]:
 fn tstd[dtype: DType, nelts: Int](t: Tensor[dtype]) -> SIMD[dtype, 1]:
     var mu: SIMD[dtype, 1] = tmean[dtype, nelts](t)
     var variance: SIMD[dtype, 1] = 0
-    
+
     @parameter
     fn vecvar[nelts: Int](idx: Int):
         let diff = t.simd_load[nelts](idx) - mu
         variance += (diff * diff).reduce_add()
+
     vectorize[nelts, vecvar](t.num_elements())
-    
+
     return sqrt(variance / t.num_elements())
 
 
 fn tmean2[dtype: DType](t: Tensor[dtype], axis: Int = 0):
-    '''Calculate mean of a 2D tensor along a specified axis.'''
+    """Calculate mean of a 2D tensor along a specified axis."""
     # TODO: every mean of vector can be calulated in parallel where each mean calculation can be vectorized
     pass
 
 
 fn tstd2[dtype: DType](t: Tensor[dtype], axis: Int = 0):
-    '''Calculate standard deviation of a 2D tensor along a specified axis.'''
+    """Calculate standard deviation of a 2D tensor along a specified axis."""
     # TODO
     pass
 
@@ -166,17 +206,20 @@ fn tstd2[dtype: DType](t: Tensor[dtype], axis: Int = 0):
 @always_inline
 fn dot[dtype: DType, nelts: Int](A: Tensor[dtype], B: Tensor[dtype]) -> Tensor[dtype]:
     var C = Tensor[dtype](A.dim(0), B.dim(1))
-    memset_zero[dtype](C.data(), C.num_elements())  
-    
+    memset_zero[dtype](C.data(), C.num_elements())
+
     @parameter
     fn calc_row(m: Int):
-        for k in range(B.dim(0)):    # TODO: test dot(4x1x28x28, 784x32) = (4x32) // mnist case
+        for k in range(
+            B.dim(0)
+        ):  # TODO: test dot(4x1x28x28, 784x32) = (4x32) // mnist case
 
             @parameter
             fn dot[nelts: Int](n: Int):
                 C.simd_store[nelts](
-                    m * C.dim(1) + n, 
-                    C.simd_load[nelts](m * C.dim(1) + n) + A[m, k] * B.simd_load[nelts](k * B.dim(1) + n)
+                    m * C.dim(1) + n,
+                    C.simd_load[nelts](m * C.dim(1) + n)
+                    + A[m, k] * B.simd_load[nelts](k * B.dim(1) + n),
                 )
 
             vectorize[nelts, dot](C.dim(1))
@@ -189,15 +232,23 @@ fn dot[dtype: DType, nelts: Int](A: Tensor[dtype], B: Tensor[dtype]) -> Tensor[d
 @always_inline
 fn transpose_2D[dtype: DType, nelts: Int](t: Tensor[dtype]) -> Tensor[dtype]:
     var t_new = Tensor[dtype](t.dim(1), t.dim(0))
-    
+
     # TODO: figure out vectorization
     # TODO: make it work for any rank
 
+    let stride = t.dim(0)
+
     @parameter
     fn proc_row(i: Int):
-        for j in range(t.dim(1)):
-            t_new[j*t.dim(0) + i] = t[i*t.dim(1) + j]
+        @parameter
+        fn proc_column[nelts: Int](j: Int):
+            t_new.data().offset(j * t.dim(0) + i).simd_strided_store[nelts](
+                t.simd_load[nelts](i * t.dim(1) + j), stride
+            )
+            # t_new[j * t.dim(0) + i] = t[i * t.dim(1) + j]
+
+        vectorize[nelts, proc_column](t.dim(1))
+
     parallelize[proc_row](t.dim(0))
 
     return t_new
-

--- a/dainemo/utils/tensorutils.mojo
+++ b/dainemo/utils/tensorutils.mojo
@@ -231,10 +231,8 @@ fn dot[dtype: DType, nelts: Int](A: Tensor[dtype], B: Tensor[dtype]) -> Tensor[d
 
 @always_inline
 fn transpose_2D[dtype: DType, nelts: Int](t: Tensor[dtype]) -> Tensor[dtype]:
+    # NOTE: This function could be deleted to use instead the transpose function
     var t_new = Tensor[dtype](t.dim(1), t.dim(0))
-
-    # TODO: figure out vectorization
-    # TODO: make it work for any rank
 
     let stride = t.dim(0)
 

--- a/test/test_tensorutils.mojo
+++ b/test/test_tensorutils.mojo
@@ -216,7 +216,7 @@ fn test_sum_mean_std() raises:
 
 
 # <-------------TRANSPOSE------------->
-from test.test_tensorutils_data import TransposeData
+from test_tensorutils_data import TransposeData
 
 
 fn test_transpose() raises:

--- a/test/test_tensorutils.mojo
+++ b/test/test_tensorutils.mojo
@@ -220,9 +220,6 @@ from test_tensorutils_data import TransposeData
 
 
 fn test_transpose() raises:
-    # TODO: figure out vectorization
-    # TODO: make it work for any rank
-
     var data = TransposeData.generate_1_test_case()
 
     var transposed = transpose_2D[dtype, nelts](data.A)

--- a/test/test_tensorutils.mojo
+++ b/test/test_tensorutils.mojo
@@ -290,16 +290,16 @@ fn test_flatten() raises:
 
 fn main():
     try:
-        # test_zero()
-        # test_fill()
-        # test_dot()
-        # test_elwise_transform()
-        # test_elwise_pow()
-        # test_elwise_tensor_tensor()
-        # test_elwise_tensor_scalar()
-        # test_elwise_batch_tensor()
-        # test_sum_mean_std()
+        test_zero()
+        test_fill()
+        test_dot()
+        test_elwise_transform()
+        test_elwise_pow()
+        test_elwise_tensor_tensor()
+        test_elwise_tensor_scalar()
+        test_elwise_batch_tensor()
+        test_sum_mean_std()
         test_transpose()
-        # test_flatten()
+        test_flatten()
     except:
         print("[ERROR] Error in tensorutils.py")

--- a/test/test_tensorutils.mojo
+++ b/test/test_tensorutils.mojo
@@ -221,6 +221,7 @@ from test_tensorutils_data import TransposeData
 
 fn test_transpose() raises:
     # Transpose 2 dimensions
+
     var data = TransposeData.generate_1_2dim_test_case()
 
     var transposed = transpose_2D[dtype, nelts](data.A)

--- a/test/test_tensorutils.mojo
+++ b/test/test_tensorutils.mojo
@@ -220,13 +220,14 @@ from test_tensorutils_data import TransposeData
 
 
 fn test_transpose() raises:
-    var data = TransposeData.generate_1_test_case()
+    # Transpose 2 dimensions
+    var data = TransposeData.generate_1_2dim_test_case()
 
     var transposed = transpose_2D[dtype, nelts](data.A)
 
     assert_tensors_equal(transposed, data.expected)
 
-    data = TransposeData.generate_2_test_case()
+    data = TransposeData.generate_2_2dim_test_case()
 
     transposed = transpose[dtype, nelts](
         data.A, data.transpose_dims[0], data.transpose_dims[1]
@@ -234,7 +235,7 @@ fn test_transpose() raises:
 
     assert_tensors_equal(transposed, data.expected)
 
-    data = TransposeData.generate_3_test_case()
+    data = TransposeData.generate_3_2dim_test_case()
 
     transposed = transpose[dtype, nelts](
         data.A, data.transpose_dims[0], data.transpose_dims[1]
@@ -242,11 +243,29 @@ fn test_transpose() raises:
 
     assert_tensors_equal(transposed, data.expected)
 
-    data = TransposeData.generate_4_test_case()
+    data = TransposeData.generate_4_2dim_test_case()
 
     transposed = transpose[dtype, nelts](
         data.A, data.transpose_dims[0], data.transpose_dims[1]
     )
+
+    assert_tensors_equal(transposed, data.expected)
+
+    # Transpose using all dimensions
+
+    data = TransposeData.generate_1_alldim_test_case()
+    var transpose_dims = DynamicVector[Int]()
+    for i in range(len(data.transpose_dims)):
+        transpose_dims.push_back(data.transpose_dims[i])
+
+    transposed = transpose[dtype, nelts](data.A, transpose_dims)
+
+    assert_tensors_equal(transposed, data.expected)
+
+    # Transpose (reverse)
+
+    data = TransposeData.generate_1_transpose_test_case()
+    transposed = transpose[dtype, nelts](data.A)
 
     assert_tensors_equal(transposed, data.expected)
 
@@ -270,16 +289,16 @@ fn test_flatten() raises:
 
 fn main():
     try:
-        test_zero()
-        test_fill()
-        test_dot()
-        test_elwise_transform()
-        test_elwise_pow()
-        test_elwise_tensor_tensor()
-        test_elwise_tensor_scalar()
-        test_elwise_batch_tensor()
-        test_sum_mean_std()
+        # test_zero()
+        # test_fill()
+        # test_dot()
+        # test_elwise_transform()
+        # test_elwise_pow()
+        # test_elwise_tensor_tensor()
+        # test_elwise_tensor_scalar()
+        # test_elwise_batch_tensor()
+        # test_sum_mean_std()
         test_transpose()
-        test_flatten()
+        # test_flatten()
     except:
         print("[ERROR] Error in tensorutils.py")

--- a/test/test_tensorutils.mojo
+++ b/test/test_tensorutils.mojo
@@ -3,8 +3,13 @@ from random import rand
 from testing import assert_equal, assert_true
 
 from dainemo.utils.tensorutils import zero, fill, dot
-from dainemo.utils.tensorutils import elwise_transform, elwise_pow, elwise_op, batch_tensor_elwise_op
-from dainemo.utils.tensorutils import tsum, tmean, tstd, transpose_2D
+from dainemo.utils.tensorutils import (
+    elwise_transform,
+    elwise_pow,
+    elwise_op,
+    batch_tensor_elwise_op,
+)
+from dainemo.utils.tensorutils import tsum, tmean, tstd, transpose_2D, transpose
 
 from math import sqrt, exp, round
 from math import add, sub, mul, div
@@ -99,7 +104,7 @@ fn test_elwise_tensor_tensor() raises:
     var t2 = Tensor[dtype](2, 10)
     fill[dtype, nelts](t1, 3.0)
     fill[dtype, nelts](t2, 3.0)
-    
+
     let result1 = elwise_op[dtype, nelts, add](t1, t2)
     var result1_expected = Tensor[dtype](2, 10)
     fill[dtype, nelts](result1_expected, 6.0)
@@ -125,7 +130,7 @@ fn test_elwise_tensor_scalar() raises:
     let a: SIMD[dtype, 1] = 2.0
     var t1 = Tensor[dtype](2, 10)
     fill[dtype, nelts](t1, 1.0)
-    
+
     let result1 = elwise_op[dtype, nelts, add](t1, a)
     var result1_expected = Tensor[dtype](2, 10)
     fill[dtype, nelts](result1_expected, 3.0)
@@ -172,64 +177,81 @@ fn test_elwise_batch_tensor() raises:
     # print(batch_result3)
 
 
-
 # <-------------SUM/MEAN/STD------------->
 fn test_sum_mean_std() raises:
     var t = Tensor[dtype](2, 10)
     var s = 0
     for i in range(20):
-        t[i] = i+1
-        s += i+1
+        t[i] = i + 1
+        s += i + 1
 
     # Not specifying the axis takes all elements regardless of the shape
     let tensor_sum = tsum[dtype, nelts](t)
     assert_equal(tensor_sum, s)
 
     let tensor_mean = tmean[dtype, nelts](t)
-    assert_equal(tensor_mean, s/20)
+    assert_equal(tensor_mean, s / 20)
 
     let tensor_std = tstd[dtype, nelts](t)
     var expected_std: SIMD[dtype, 1] = 0
     for i in range(20):
-        expected_std += (i+1 - tensor_mean)**2
-    expected_std = sqrt(expected_std/20)
+        expected_std += (i + 1 - tensor_mean) ** 2
+    expected_std = sqrt(expected_std / 20)
     assert_equal(tensor_std, expected_std)
 
     # When specifying the axis you can sum across batches
     let batch_sum_0 = tsum[dtype, nelts](t, axis=0)
     var expected_batch_sum_0 = Tensor[dtype](1, 10)
     for i in range(10):
-        expected_batch_sum_0[i] = (i+1) + (i+1+10)
+        expected_batch_sum_0[i] = (i + 1) + (i + 1 + 10)
     assert_tensors_equal(batch_sum_0, expected_batch_sum_0)
 
     let batch_sum_1 = tsum[dtype, nelts](t, axis=1)
     var expected_batch_sum_1 = Tensor[dtype](2, 1)
-    expected_batch_sum_1[0] = 1+2+3+4+5+6+7+8+9+10
-    expected_batch_sum_1[1] = 11+12+13+14+15+16+17+18+19+20
+    expected_batch_sum_1[0] = 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10
+    expected_batch_sum_1[1] = 11 + 12 + 13 + 14 + 15 + 16 + 17 + 18 + 19 + 20
     assert_tensors_equal(batch_sum_1, expected_batch_sum_1)
 
     # TODO: mean / std across a specified axis
 
 
 # <-------------TRANSPOSE------------->
+from test.test_tensorutils_data import TransposeData
+
+
 fn test_transpose() raises:
     # TODO: figure out vectorization
     # TODO: make it work for any rank
-    var A = Tensor[dtype](2, 3)
-    for i in range(6):
-        A[i] = i+1
-    
-    let transposed = transpose_2D[dtype, nelts](A)
-    
-    var expected = Tensor[dtype](3, 2)
-    expected[0] = 1
-    expected[1] = 4
-    expected[2] = 2
-    expected[3] = 5
-    expected[4] = 3
-    expected[5] = 6
-    
-    assert_tensors_equal(transposed, expected)
+
+    var data = TransposeData.generate_1_test_case()
+
+    var transposed = transpose_2D[dtype, nelts](data.A)
+
+    assert_tensors_equal(transposed, data.expected)
+
+    data = TransposeData.generate_2_test_case()
+
+    transposed = transpose[dtype, nelts](
+        data.A, data.transpose_dims[0], data.transpose_dims[1]
+    )
+
+    assert_tensors_equal(transposed, data.expected)
+
+    data = TransposeData.generate_3_test_case()
+
+    transposed = transpose[dtype, nelts](
+        data.A, data.transpose_dims[0], data.transpose_dims[1]
+    )
+
+    assert_tensors_equal(transposed, data.expected)
+
+    data = TransposeData.generate_4_test_case()
+
+    transposed = transpose[dtype, nelts](
+        data.A, data.transpose_dims[0], data.transpose_dims[1]
+    )
+
+    assert_tensors_equal(transposed, data.expected)
 
 
 # <-------------FLATTEN/RESHAPE------------->
@@ -237,18 +259,19 @@ fn test_flatten() raises:
     var A = Tensor[dtype](2, 3)
     var B = Tensor[dtype](6)
     for i in range(6):
-        A[i] = i+1
-        B[i] = i+1
+        A[i] = i + 1
+        B[i] = i + 1
 
-    var A_flat = A.reshape(TensorShape(A.num_elements()))       # or A.ireshape to modify in place
+    var A_flat = A.reshape(
+        TensorShape(A.num_elements())
+    )  # or A.ireshape to modify in place
     assert_tensors_equal(A_flat, B)
 
-    let A_resh = A_flat.reshape(B.shape())                      # or A_flat.ireshape to modify in place
+    let A_resh = A_flat.reshape(B.shape())  # or A_flat.ireshape to modify in place
     assert_tensors_equal(A_resh, A)
 
 
 fn main():
- 
     try:
         test_zero()
         test_fill()

--- a/test/test_tensorutils_data.mojo
+++ b/test/test_tensorutils_data.mojo
@@ -5,9 +5,9 @@ alias dtype = DType.float32
 struct TransposeData:
     var A: Tensor[dtype]
     var expected: Tensor[dtype]
-    var transpose_dims: StaticIntTuple[2]
+    var transpose_dims: VariadicList[Int]
 
-    fn __init__(inout self, A: Tensor[dtype], expected: Tensor[dtype], transpose_dims: StaticIntTuple[2]):
+    fn __init__(inout self, A: Tensor[dtype], expected: Tensor[dtype], transpose_dims: VariadicList[Int]):
         self.A = A
         self.expected = expected
         self.transpose_dims = transpose_dims
@@ -30,36 +30,36 @@ struct TransposeData:
         return A ^
 
     @staticmethod
-    fn generate_1_test_case() -> TransposeData:
+    fn generate_1_2dim_test_case() -> TransposeData:
         let A = TransposeData.generate_tensor(2, 3)
         let expected = StaticIntTuple[6](1, 4, 2, 5, 3, 6)
-        let tranpose_dims = StaticIntTuple[2](0, 1)
+        let tranpose_dims = VariadicList[Int](0, 1)
         let B = TransposeData.generate_expected_tensor(expected, 3, 2)
 
         return TransposeData(A, B, tranpose_dims)
 
     @staticmethod
-    fn generate_2_test_case() -> TransposeData:
+    fn generate_2_2dim_test_case() -> TransposeData:
         let A = TransposeData.generate_tensor(2, 3, 2)
         let expected = StaticIntTuple[12](1, 7, 3, 9, 5, 11, 2, 8, 4, 10, 6, 12)
-        let tranpose_dims = StaticIntTuple[2](0, 2)
+        let tranpose_dims = VariadicList[Int](0, 2)
         let B = TransposeData.generate_expected_tensor(expected, 2, 3, 2)
 
         return TransposeData(A, B, tranpose_dims)
 
     @staticmethod
-    fn generate_3_test_case() -> TransposeData:
+    fn generate_3_2dim_test_case() -> TransposeData:
         let A = TransposeData.generate_tensor(2, 3, 2, 3)
         let expected = StaticIntTuple[36](1, 2, 3, 7, 8, 9, 13, 14, 15, 4, 5, 6, 
         10, 11, 12, 16, 17, 18, 19, 20, 21, 25, 26, 27, 31, 32, 33, 22, 23, 24, 
         28, 29, 30, 34, 35, 36)
-        let tranpose_dims = StaticIntTuple[2](1, 2)
+        let tranpose_dims = VariadicList[Int](1, 2)
         let B = TransposeData.generate_expected_tensor(expected, 2, 2, 3, 3)
 
         return TransposeData(A, B, tranpose_dims)
 
     @staticmethod
-    fn generate_4_test_case() -> TransposeData:
+    fn generate_4_2dim_test_case() -> TransposeData:
         let A = TransposeData.generate_tensor(3, 2, 3, 2, 3)
         let expected = StaticIntTuple[108](1, 2, 3, 19, 20, 21, 7, 8, 9, 25, 
         26, 27, 13, 14, 15, 31, 32, 33, 4, 5, 6, 22, 23, 24, 10, 11, 12, 28, 
@@ -69,7 +69,27 @@ struct TransposeData:
         98, 99, 85, 86, 87, 103, 104, 105, 76, 77, 78, 94, 95, 96, 82, 83, 84, 
         100, 101, 102, 88, 89, 90, 106, 107, 108
         )
-        let tranpose_dims = StaticIntTuple[2](1, 3)
+        let tranpose_dims = VariadicList[Int](1, 3)
         let B = TransposeData.generate_expected_tensor(expected, 3, 2, 3, 2, 3)
+
+        return TransposeData(A, B, tranpose_dims)
+
+    @staticmethod
+    fn generate_1_alldim_test_case() -> TransposeData:
+        let A = TransposeData.generate_tensor(2, 3, 2, 3)
+        let expected = StaticIntTuple[36](1,4,2,5,3,6,19,22,20,23,21,24,7,10,8,
+        11,9,12,25,28,26,29,27,30,13,16,14,17,15,18,31,34,32,35,33,36)
+        let tranpose_dims = VariadicList[Int](1, 0, 3, 2)
+        let B = TransposeData.generate_expected_tensor(expected, 3, 2, 3, 2)
+
+        return TransposeData(A, B, tranpose_dims)
+
+    @staticmethod
+    fn generate_1_transpose_test_case() -> TransposeData:
+        let A = TransposeData.generate_tensor(2, 3, 2, 3)
+        let expected = StaticIntTuple[36](1,19,7,25,13,31,4,22,10,28,16,34,2,20,
+        8,26,14,32,5,23,11,29,17,35,3,21,9,27,15,33,6,24,12,30,18,36)
+        let tranpose_dims = VariadicList[Int](3, 2, 1, 0)
+        let B = TransposeData.generate_expected_tensor(expected, 3, 2, 3, 2)
 
         return TransposeData(A, B, tranpose_dims)

--- a/test/test_tensorutils_data.mojo
+++ b/test/test_tensorutils_data.mojo
@@ -1,0 +1,75 @@
+from tensor import Tensor, TensorShape
+
+alias dtype = DType.float32
+
+struct TransposeData:
+    var A: Tensor[dtype]
+    var expected: Tensor[dtype]
+    var transpose_dims: StaticIntTuple[2]
+
+    fn __init__(inout self, A: Tensor[dtype], expected: Tensor[dtype], transpose_dims: StaticIntTuple[2]):
+        self.A = A
+        self.expected = expected
+        self.transpose_dims = transpose_dims
+
+    @staticmethod
+    fn generate_tensor(*shape: Int) -> Tensor[dtype]:
+        var A = Tensor[dtype](shape)
+        let size = A.num_elements()
+        for i in range(size):
+            A[i] = i + 1
+        return A ^
+
+    @staticmethod
+    fn generate_expected_tensor[
+        size: Int
+    ](data: StaticIntTuple[size], *shape: Int) -> Tensor[dtype]:
+        var A = Tensor[dtype](shape)
+        for i in range(size):
+            A[i] = data[i]
+        return A ^
+
+    @staticmethod
+    fn generate_1_test_case() -> TransposeData:
+        let A = TransposeData.generate_tensor(2, 3)
+        let expected = StaticIntTuple[6](1, 4, 2, 5, 3, 6)
+        let tranpose_dims = StaticIntTuple[2](0, 1)
+        let B = TransposeData.generate_expected_tensor(expected, 3, 2)
+
+        return TransposeData(A, B, tranpose_dims)
+
+    @staticmethod
+    fn generate_2_test_case() -> TransposeData:
+        let A = TransposeData.generate_tensor(2, 3, 2)
+        let expected = StaticIntTuple[12](1, 7, 3, 9, 5, 11, 2, 8, 4, 10, 6, 12)
+        let tranpose_dims = StaticIntTuple[2](0, 2)
+        let B = TransposeData.generate_expected_tensor(expected, 2, 3, 2)
+
+        return TransposeData(A, B, tranpose_dims)
+
+    @staticmethod
+    fn generate_3_test_case() -> TransposeData:
+        let A = TransposeData.generate_tensor(2, 3, 2, 3)
+        let expected = StaticIntTuple[36](1, 2, 3, 7, 8, 9, 13, 14, 15, 4, 5, 6, 
+        10, 11, 12, 16, 17, 18, 19, 20, 21, 25, 26, 27, 31, 32, 33, 22, 23, 24, 
+        28, 29, 30, 34, 35, 36)
+        let tranpose_dims = StaticIntTuple[2](1, 2)
+        let B = TransposeData.generate_expected_tensor(expected, 2, 2, 3, 3)
+
+        return TransposeData(A, B, tranpose_dims)
+
+    @staticmethod
+    fn generate_4_test_case() -> TransposeData:
+        let A = TransposeData.generate_tensor(3, 2, 3, 2, 3)
+        let expected = StaticIntTuple[108](1, 2, 3, 19, 20, 21, 7, 8, 9, 25, 
+        26, 27, 13, 14, 15, 31, 32, 33, 4, 5, 6, 22, 23, 24, 10, 11, 12, 28, 
+        29, 30, 16, 17, 18, 34, 35, 36, 37, 38, 39, 55, 56, 57, 43, 44, 45, 61, 
+        62, 63, 49, 50, 51, 67, 68, 69, 40, 41, 42, 58, 59, 60, 46, 47, 48, 64, 
+        65, 66, 52, 53, 54, 70, 71, 72, 73, 74, 75, 91, 92, 93, 79, 80, 81, 97, 
+        98, 99, 85, 86, 87, 103, 104, 105, 76, 77, 78, 94, 95, 96, 82, 83, 84, 
+        100, 101, 102, 88, 89, 90, 106, 107, 108
+        )
+        let tranpose_dims = StaticIntTuple[2](1, 3)
+        let B = TransposeData.generate_expected_tensor(expected, 3, 2, 3, 2, 3)
+
+        return TransposeData(A, B, tranpose_dims)


### PR DESCRIPTION
## This PR adds three things

### Added vectorization for transpose_2d
I added *vectorization* for this function using *simd_strided_store* and *simd_load*

### Added a transpose function for any rank
This PR also add a transpose function that works for any rank and has *parallelization* and *vectorization*

### Added new tests for transpose
Also this PR added new tests for the transpose function to test for more rank sizes. And I also divided the test to another file called *test_tensorutils_data*, this file generates the data to be used to test with the assert equals, I did this division to not add a lot of code to the original test file, so as to not make the *test_tensorutils* file more difficult to read, but also to not have to deal with the *mojo formater*, if i had an array that was bigger than what could be in the screen, the *mojo format* would make put each value of the array in a new line, so I dint want to add *108 lines* just to have the expected arrays.