### PR TITLE
Conv2D

### DIFF
--- a/dainemo/autograd/node.mojo
+++ b/dainemo/autograd/node.mojo
@@ -3,21 +3,21 @@ from tensor import Tensor, TensorShape
 
 from dainemo import GRAPH
 from dainemo.utils.uuid import uuid
-from dainemo.utils.tensorutils import fill, elwise_op, tsum
+from dainemo.utils.tensorutils import fill, elwise_op, tsum, calculate_strides
 
 
-fn backward_fn_placeholder[dtype: DType](
-        ug: Tensor[dtype],
-        tensor_vec: DynamicVector[String],
-        tensor_id: Int
-    ) -> Tensor[dtype]:
+fn backward_fn_placeholder[
+    dtype: DType
+](ug: Tensor[dtype], tensor_vec: DynamicVector[String], tensor_id: Int) -> Tensor[
+    dtype
+]:
     print("[ERROR]: Backward function placeholder")
     return Tensor[dtype](ug.shape())
 
 
 @value
 struct Node[dtype: DType = DType.float32](CollectionElement, Stringable):
-    '''
+    """
     A Node data structure that is used to build the computational graph.
         - tensor: The tensor that is stored in the node.
         - requires_grad: If true, the node will be included in the backward pass.
@@ -27,25 +27,39 @@ struct Node[dtype: DType = DType.float32](CollectionElement, Stringable):
         - param: If true, the node is a parameter of the model. (requires_grad indicates if it is trainable or not).
         - children: The children of the node in the graph.
         - parents: The parents of the node in the graph.
-    '''
-    
+    """
+
     var tensor: Tensor[dtype]
-    var requires_grad: Bool                     # TODO: can probably be compile time known
+    var strides: DynamicVector[Int]
+    var requires_grad: Bool  # TODO: can probably be compile time known
     var requires_broadcast: Bool
     var uuid: String
     var grad: Tensor[dtype]
-    var param: Bool                             # TODO: can probably be compile time known
+    var param: Bool  # TODO: can probably be compile time known
     var visited: Bool
     var children: DynamicVector[String]
     var parents: DynamicVector[String]
     var parent_broadcast_shape: TensorShape
-    var backward_fn: fn(ug: Tensor[dtype], tensor_vec: DynamicVector[String], tensor_id: Int) -> Tensor[dtype]
+    var backward_fn: fn (
+        ug: Tensor[dtype], tensor_vec: DynamicVector[String], tensor_id: Int
+    ) -> Tensor[dtype]
 
-    var optim_rms_grad: Tensor[dtype]           # TODO: Remove. Only applicable for param == True (extra trait?)
-    var optim_momentum_grad: Tensor[dtype]      # TODO: Remove. Only applicable for param == True (extra trait?)
+    var optim_rms_grad: Tensor[
+        dtype
+    ]  # TODO: Remove. Only applicable for param == True (extra trait?)
+    var optim_momentum_grad: Tensor[
+        dtype
+    ]  # TODO: Remove. Only applicable for param == True (extra trait?)
 
-    fn __init__(inout self, tensor: Tensor[dtype], requires_grad: Bool = False, requires_broadcast: Bool = True, param: Bool = False):
+    fn __init__(
+        inout self,
+        tensor: Tensor[dtype],
+        requires_grad: Bool = False,
+        requires_broadcast: Bool = True,
+        param: Bool = False,
+    ):
         self.tensor = tensor
+        self.strides = calculate_strides(tensor.shape())
         self.requires_grad = requires_grad
         self.requires_broadcast = requires_broadcast
         self.uuid = uuid()
@@ -56,67 +70,61 @@ struct Node[dtype: DType = DType.float32](CollectionElement, Stringable):
         self.parents = DynamicVector[String]()
         self.parent_broadcast_shape = tensor.shape()
         self.backward_fn = backward_fn_placeholder[dtype]
-        
+
         self.optim_rms_grad = Tensor[dtype](self.grad.shape())
         self.optim_momentum_grad = Tensor[dtype](self.grad.shape())
 
-
     fn add_child(inout self, node: Node[dtype]):
-        ''''
+        """'
         Adds a child to the node.
-        '''
+        """
         self.children.push_back(node.uuid)
-    
 
     fn add_parent(inout self, node: Node[dtype]):
-        '''
+        """
         Adds a parent to the node.
-        '''
+        """
         self.parents.push_back(node.uuid)
 
-
     fn visit_all_children(inout self):
-        '''
+        """
         Marks all children of the node as visited in the graph.
-        '''
+        """
         for i in range(self.children.size):
             GRAPH.mark_visited(self.children[i])
-    
 
     fn are_children_visited(inout self) -> Bool:
-        '''
+        """
         Checks if all children of the node are visited in the graph.
-        '''
+        """
         for i in range(self.children.size):
             let idx = GRAPH.get_node_idx(self.children[i])
             if not GRAPH.graph[idx].visited:
                 return False
         return True
 
-
     fn are_parents_visited(inout self) -> Bool:
-        '''
+        """
         Checks if all parents of the node are visited in the graph.
-        '''
+        """
         for i in range(self.parents.size):
             let idx = GRAPH.get_node_idx(self.parents[i])
             if not GRAPH.graph[idx].visited:
                 return False
         return True
 
-
     fn backward(inout self, upper_grad: Tensor[dtype], retain_graph: Bool = False):
-        '''
+        """
         Initial entrypoint for the backward pass. (as loss.backward() is called)
         Calculates the order of the backward pass and calls the backward function of the node to calculate the gradients.
         - upper_grad: The gradient to start the backward pass with. Shape should be equal to the shape of the node's tensor.
         - retain_graph: If true, the graph will not reset after the backward pass.
-        '''
+        """
 
         if self.requires_grad:
             # TODO: Check if upper_grad.shape == self.tensor.shape (raises)
             self.accumulate_grad(upper_grad)
-            
+
             # 1. Topological sort of the graph.
             # Visit all children so that they aren't included in the backward pass
             # This allows gradient calculation for any intermediate node in the graph
@@ -129,7 +137,7 @@ struct Node[dtype: DType = DType.float32](CollectionElement, Stringable):
             # 2. Mark as visited & Backward pass on 1st current node without calulating the gradient
             GRAPH.mark_visited(self.uuid)
             self.backward_gradient(retain_graph, calculate_grads=False)
-            
+
             # 3. Calculate the gradients for the nodes in topological order
             for i in range(1, sorted_nodes.size):
                 var node = GRAPH.graph[GRAPH.get_node_idx(sorted_nodes[i])]
@@ -139,21 +147,19 @@ struct Node[dtype: DType = DType.float32](CollectionElement, Stringable):
             if not retain_graph:
                 GRAPH.reset()
 
-
     fn backward(inout self, retain_graph: Bool = False):
-        '''
+        """
         Function overload for: Default upper_grad, tensor of 1.0, with shape equal to the shape of the node's tensor.
-        '''
+        """
         var upper_grad = Tensor[dtype](self.tensor.shape())
         alias nelts: Int = simdwidthof[dtype]()
         fill[dtype, nelts](upper_grad, 1.0)
         self.backward(upper_grad, retain_graph)
 
-
     fn accumulate_grad(inout self, grad: Tensor[dtype]):
-        '''
+        """
         Accumulates the gradient of the node in the graph.
-        '''
+        """
         # TODO: self.grad = elwise_op[dtype, nelts, add](self.grad, grad) --> only
         # Lifetimes (__getitem__ of a dynamic vector returns a copy and not a reference)
         let my_idx = GRAPH.get_node_idx(self.uuid)
@@ -164,7 +170,6 @@ struct Node[dtype: DType = DType.float32](CollectionElement, Stringable):
             my_node.grad[i] += grad[i].cast[DType.float32]()
         GRAPH.graph[my_idx] = my_node
 
-
     fn accumulate_grad2(inout self, grad: Tensor[DType.float32]):
         # BUG: overload as workaround: should be one generic dtype
         let my_idx = GRAPH.get_node_idx(self.uuid)
@@ -172,12 +177,11 @@ struct Node[dtype: DType = DType.float32](CollectionElement, Stringable):
         alias nelts: Int = simdwidthof[DType.float32]()
         my_node.grad = elwise_op[DType.float32, nelts, add](my_node.grad, grad)
         GRAPH.graph[my_idx] = my_node
-    
 
     fn backward_gradient(inout self, retain_graph: Bool, calculate_grads: Bool = True):
-        '''
+        """
         Gradient calculation for the node during the backward pass.
-        '''
+        """
 
         for c in range(self.children.size):
             let child_idx = GRAPH.get_node_idx(self.children[c])
@@ -192,28 +196,32 @@ struct Node[dtype: DType = DType.float32](CollectionElement, Stringable):
                         break
 
                 var grad = child.backward_fn(child.grad, child.parents, tensor_id)
-                self.unbroadcast_data(grad, self.tensor.shape(), child.parent_broadcast_shape)
+                self.unbroadcast_data(
+                    grad, self.tensor.shape(), child.parent_broadcast_shape
+                )
                 self.accumulate_grad2(grad)
 
-
     @staticmethod
-    fn unbroadcast_data(inout data: Tensor[DType.float32], original_shape: TensorShape, broadcast_shape: TensorShape):
-        '''
+    fn unbroadcast_data(
+        inout data: Tensor[DType.float32],
+        original_shape: TensorShape,
+        broadcast_shape: TensorShape,
+    ):
+        """
         Unbroadcasts the data to the original shape of the node.
-        '''
+        """
         alias none_bc = TensorShape(-1, -1)
         alias nelts: Int = simdwidthof[dtype]()
         if broadcast_shape != none_bc:
             for dim in range(min(original_shape.rank(), broadcast_shape.rank())):
                 if original_shape[dim] != broadcast_shape[dim]:
                     data = tsum[DType.float32, 1](data, axis=dim)
-      
 
     fn topological_sort(inout self, inout sorted_nodes: DynamicVector[String]):
-        '''
+        """
         Topological sort of the graph.
         Efficiently perform the backwards pass by making sure that all the children's gradients are calculated before the parents.
-        '''
+        """
 
         # Check if all children are visited
         # 1. If not, topological sort on the children
@@ -224,7 +232,7 @@ struct Node[dtype: DType = DType.float32](CollectionElement, Stringable):
                 if not child.visited:
                     child.topological_sort(sorted_nodes)
 
-        # 2. If yes, add node to array 
+        # 2. If yes, add node to array
         #    & topological sort on the parents to go up the graph
         else:
             GRAPH.mark_visited(self.uuid)
@@ -235,15 +243,13 @@ struct Node[dtype: DType = DType.float32](CollectionElement, Stringable):
                 if not parent.visited:
                     parent.topological_sort(sorted_nodes)
 
-
     fn reset_relations(inout self):
-        '''
+        """
         Resets the relations of the node in the graph.
-        '''
+        """
         self.children = DynamicVector[String]()
         self.parents = DynamicVector[String]()
 
-    
     fn __str__(self) -> String:
         var res = String("Node(")
         res += self.uuid

--- a/dainemo/autograd/ops/conv.mojo
+++ b/dainemo/autograd/ops/conv.mojo
@@ -61,11 +61,14 @@ struct CONV2D:
             all_checks: Bool = True
         ](batch: Int, out_ch: Int, x: Int, y: Int):
             var result: SIMD[dtype, 1] = 0
+
+            let ix_base = x * stride[0] - padding[0]
+            let iy_base = y * stride[1] - padding[1]
             for in_ch in range(inputs.tensor.dim(1)):
                 for kx in range(kernel.tensor.dim(2)):
                     for ky in range(kernel.tensor.dim(3)):
-                        let ix = x * stride[0] - padding[0] + kx
-                        let iy = y * stride[1] - padding[1] + ky
+                        let ix = ix_base + kx * dilation[0]
+                        let iy = iy_base + ky * dilation[1]
 
                         @parameter
                         if all_checks:
@@ -105,17 +108,17 @@ struct CONV2D:
             outputs[output_index] = result + bias.tensor[out_ch]
 
         let oH_border_0 = 0
-        let oH_border_1 = (padding[0] + stride[0] + 1) / stride[0]
+        let oH_border_1 = (padding[0] + stride[0] + 1) // stride[0]
         let oH_border_2 = (
-            inputs.tensor.dim(2) + padding[0] - kernel.tensor.dim(2)
-        ) / stride[0]
+            inputs.tensor.dim(2) + padding[0] - kernel.tensor.dim(2) * dilation[0]
+        ) // stride[0]
         let oH_border_3 = outputs.dim(2)
 
         let oW_border_0 = 0
-        let oW_border_1 = (padding[1] + stride[0] + 1) / stride[1]
+        let oW_border_1 = (padding[1] + stride[0] + 1) // stride[1]
         let oW_border_2 = (
-            inputs.tensor.dim(3) + padding[1] - kernel.tensor.dim(3)
-        ) / stride[1]
+            inputs.tensor.dim(3) + padding[1] - kernel.tensor.dim(3) * dilation[1]
+        ) // stride[1]
         let oW_border_3 = outputs.dim(3)
 
         for batch in range(inputs.tensor.dim(0)):

--- a/dainemo/autograd/ops/conv.mojo
+++ b/dainemo/autograd/ops/conv.mojo
@@ -8,7 +8,7 @@ from dainemo.utils.tensorutils import calculate_strides
 
 # <------------GENERAL CONV METHODS------------>
 fn get_result_shape[
-    padding: StaticIntTuple[2], stride: Int
+    padding: StaticIntTuple[2], stride: StaticIntTuple[2]
 ](input_shape: TensorShape, kernel_shape: TensorShape) -> StaticIntTuple[2]:
     """
     Calculates the X and Y dimensions of the resulting convolution.
@@ -17,13 +17,13 @@ fn get_result_shape[
         dimension Y on index -1.
     """
 
-    let result_x_dim = floor[DType.float64, 1](
-        ((input_shape[-2] + (2 * padding[0]) - kernel_shape[-2]) / stride) + 1
-    ).to_int()
+    let result_x_dim = (
+        (input_shape[-2] + (2 * padding[0]) - kernel_shape[-2]) // stride[0]
+    ) + 1
 
-    let result_y_dim = floor[DType.float64, 1](
-        ((input_shape[-1] + (2 * padding[1]) - kernel_shape[-1]) / stride) + 1
-    ).to_int()
+    let result_y_dim = (
+        (input_shape[-1] + (2 * padding[1]) - kernel_shape[-1]) // stride[1]
+    ) + 1
 
     return StaticIntTuple[2](result_x_dim, result_y_dim)
 

--- a/dainemo/autograd/ops/conv.mojo
+++ b/dainemo/autograd/ops/conv.mojo
@@ -104,17 +104,17 @@ struct CONV2D:
             outputs[output_index] = result + bias.tensor[out_ch]
 
         let oH_border_0 = 0
-        let oH_border_1 = (padding + kernel.strides[0] + 1) / kernel.strides[0]
+        let oH_border_1 = (padding + stride + 1) / stride
         let oH_border_2 = (
             inputs.tensor.dim(2) + padding - kernel.tensor.dim(2)
-        ) / kernel.strides[0]
+        ) / stride
         let oH_border_3 = outputs.dim(2)
 
         let oW_border_0 = 0
-        let oW_border_1 = (padding + kernel.strides[1] + 1) / kernel.strides[1]
+        let oW_border_1 = (padding + stride + 1) / stride
         let oW_border_2 = (
             inputs.tensor.dim(3) + padding - kernel.tensor.dim(3)
-        ) / kernel.strides[1]
+        ) / stride
         let oW_border_3 = outputs.dim(3)
 
         for batch in range(inputs.tensor.dim(0)):

--- a/dainemo/autograd/ops/conv.mojo
+++ b/dainemo/autograd/ops/conv.mojo
@@ -145,13 +145,15 @@ struct CONV2D:
                     for y in range(outputs.dim(3)):
                         kernel_iteration(batch, out_ch, x, y)
 
-        return GRAPH.create_graph_node[Self.backward[padding, stride]](
+        return GRAPH.create_graph_node[Self.backward[padding, stride, dilation]](
             outputs, inputs, kernel, bias
         )
 
     @staticmethod
     fn backward[
-        padding: StaticIntTuple[2], stride: StaticIntTuple[2]
+        padding: StaticIntTuple[2],
+        stride: StaticIntTuple[2],
+        dilation: StaticIntTuple[2],
     ](ug: Tensor[dtype], tensor_vec: DynamicVector[String], tensor_id: Int) -> Tensor[
         dtype
     ]:
@@ -179,11 +181,13 @@ struct CONV2D:
                 for out_ch in range(ug.dim(1)):
                     for ux in range(ug.dim(2)):
                         for uy in range(ug.dim(3)):
+                            let ix_base = ux * stride[0] - padding[0]
+                            let iy_base = uy * stride[1] - padding[1]
                             for in_ch in range(inputs.dim(1)):
                                 for kx in range(kernel.dim(2)):
                                     for ky in range(kernel.dim(3)):
-                                        let ix = ux * stride[0] - padding[0] + kx
-                                        let iy = uy * stride[1] - padding[1] + ky
+                                        let ix = ix_base + kx * dilation[0]
+                                        let iy = iy_base + ky * dilation[1]
 
                                         if (
                                             ix < 0
@@ -231,8 +235,12 @@ struct CONV2D:
                             for batch in range(inputs.dim(0)):
                                 for ux in range(ug.dim(2)):
                                     for uy in range(ug.dim(3)):
-                                        let ix = ux * stride[0] - padding[0] + kx
-                                        let iy = uy * stride[1] - padding[1] + ky
+                                        let ix = ux * stride[0] - padding[
+                                            0
+                                        ] + kx * dilation[0]
+                                        let iy = uy * stride[1] - padding[
+                                            1
+                                        ] + ky * dilation[1]
 
                                         if (
                                             ix < 0

--- a/dainemo/nn/layers/conv.mojo
+++ b/dainemo/nn/layers/conv.mojo
@@ -8,8 +8,9 @@ from dainemo.autograd.ops.conv import CONV2D
 
 # <------------CONV2D------------>
 struct Conv2d[
-    padding: Int,
-    stride: Int
+    padding: StaticIntTuple[2] = 0,
+    stride: StaticIntTuple[2] = 1,
+    dilation: StaticIntTuple[2] = 1,
 ]:
     """
     A 2D Convolution Layer.
@@ -24,23 +25,34 @@ struct Conv2d[
     var weights: Node[dtype]
     var bias: Node[dtype]
 
-    fn __init__(inout self, in_channels: Int, out_channels: Int, kernel_size: Int):           
+    fn __init__(inout self, in_channels: Int, out_channels: Int, kernel_size: Int):
         self.weights = Node[dtype](
             rand[dtype](out_channels, in_channels, kernel_size, kernel_size),
             requires_grad=True,
-            param=True
+            param=True,
         )
-        self.bias = Node[dtype](Tensor[dtype](out_channels), requires_grad=True, param=True)
+        self.bias = Node[dtype](
+            Tensor[dtype](out_channels), requires_grad=True, param=True
+        )
         GRAPH.add_node(self.weights)
         GRAPH.add_node(self.bias)
 
-    fn __init__(inout self, in_channels: Int, out_channels: Int, kernel_size: Tuple[Int, Int]):
+    fn __init__(
+        inout self, in_channels: Int, out_channels: Int, kernel_size: Tuple[Int, Int]
+    ):
         self.weights = Node[dtype](
-            rand[dtype](out_channels, in_channels, kernel_size.get[0, Int](), kernel_size.get[1, Int]()),
+            rand[dtype](
+                out_channels,
+                in_channels,
+                kernel_size.get[0, Int](),
+                kernel_size.get[1, Int](),
+            ),
             requires_grad=True,
-            param=True
+            param=True,
         )
-        self.bias = Node[dtype](Tensor[dtype](out_channels), requires_grad=True, param=True)
+        self.bias = Node[dtype](
+            Tensor[dtype](out_channels), requires_grad=True, param=True
+        )
         GRAPH.add_node(self.weights)
         GRAPH.add_node(self.bias)
 
@@ -50,12 +62,12 @@ struct Conv2d[
         """
 
         # COPY self.weight & self.bias directly from GRAPH
-        # Workaround because model parameters are created and change in copies. 
+        # Workaround because model parameters are created and change in copies.
         # TODO: Redo when lifetimes are there. [INVESTIGATE HOW TO AVOID THIS]
         let weights = GRAPH.graph[GRAPH.get_node_idx(self.weights.uuid)]
         let bias = GRAPH.graph[GRAPH.get_node_idx(self.bias.uuid)]
 
-        return CONV2D.forward[padding, stride](inputs, weights, bias)
+        return CONV2D.forward[padding, stride, dilation](inputs, weights, bias)
 
     fn __call__(self, inputs: Node[dtype]) -> Node[dtype]:
         return self.forward(inputs)

--- a/test/test_conv.mojo
+++ b/test/test_conv.mojo
@@ -16,7 +16,6 @@ alias nelts: Int = simdwidthof[dtype]()
 
 
 fn test_get_result_shape() raises:
-
     # padding=2, stride=1
     # input shape: (4, 28, 28)  kernel shape: (1, 16)
     # result:  (32, 17)
@@ -53,18 +52,18 @@ def to_numpy(tensor: Tensor) -> PythonObject:
         pyarray = np.empty((tensor.dim(0), tensor.dim(1), tensor.dim(2), tensor.dim(3)))
     else:
         print("Error: rank not supported: ", rank)
-    
+
     for i in range(tensor.num_elements()):
         pyarray.itemset((i), tensor[i])
-   
+
     return pyarray
 
 
-fn to_tensor(np_array: PythonObject) raises-> Tensor[dtype]:
+fn to_tensor(np_array: PythonObject) raises -> Tensor[dtype]:
     var shape = DynamicVector[Int]()
     for i in range(np_array.ndim):
         shape.push_back(np_array.shape[i].to_float64().to_int())
-    
+
     var tensor = Tensor[dtype](TensorShape(shape))
 
     for i in range(tensor.num_elements()):
@@ -81,9 +80,16 @@ struct torch_conv2d_output:
     var expected_bias_grad: Tensor[dtype]
 
 
-fn torch_conv2d(inputs: Tensor, kernel: Tensor, bias: Tensor, padding: Int, stride: Int, upper_grad: Tensor) -> torch_conv2d_output:
+fn torch_conv2d(
+    inputs: Tensor,
+    kernel: Tensor,
+    bias: Tensor,
+    padding: Int,
+    stride: Int,
+    upper_grad: Tensor,
+) -> torch_conv2d_output:
     let out: torch_conv2d_output
-    
+
     try:
         let torch = Python.import_module("torch")
         let F = Python.import_module("torch.nn.functional")
@@ -92,14 +98,8 @@ fn torch_conv2d(inputs: Tensor, kernel: Tensor, bias: Tensor, padding: Int, stri
         let inputs = torch.from_numpy(to_numpy(inputs)).requires_grad_(True)
         let weights = torch.from_numpy(to_numpy(kernel)).requires_grad_(True)
         let bias = torch.from_numpy(to_numpy(bias)).requires_grad_(True)
-        
-        let expected = F.conv2d(
-            inputs, 
-            weights,
-            bias,
-            stride,
-            padding
-        )
+
+        let expected = F.conv2d(inputs, weights, bias, stride, padding)
 
         # uppergrad & backwards
         let upper_grad = torch.from_numpy(to_numpy(upper_grad))
@@ -128,13 +128,15 @@ fn test_forward_1() raises:
     alias padding = 2
     alias stride = 1
     var inputs = Tensor[dtype](4, 1, 28, 28)
-    var kernel = Tensor[dtype](1, 1, 1 , 16)
+    var kernel = Tensor[dtype](1, 1, 1, 16)
     fill[dtype, nelts](inputs, 1.0)
     fill[dtype, nelts](kernel, 1.0)
     let bias = Tensor[dtype](1)
 
     let res = CONV2D.forward[padding, stride](inputs, kernel, bias)
-    let torch_out = torch_conv2d(inputs, kernel, bias=bias, padding=padding, stride=stride, upper_grad=res.grad)
+    let torch_out = torch_conv2d(
+        inputs, kernel, bias=bias, padding=padding, stride=stride, upper_grad=res.grad
+    )
     assert_tensors_equal(res.tensor, torch_out.expected)
     GRAPH.reset_all()
 
@@ -153,7 +155,30 @@ fn test_forward_2() raises:
     fill[dtype, nelts](bias, 66.99)
 
     let res = CONV2D.forward[padding, stride](inputs, kernel, bias)
-    let torch_out = torch_conv2d(inputs, kernel, bias=bias, padding=padding, stride=stride, upper_grad=res.grad)
+    let torch_out = torch_conv2d(
+        inputs, kernel, bias=bias, padding=padding, stride=stride, upper_grad=res.grad
+    )
+    assert_tensors_equal(res.tensor, torch_out.expected)
+    GRAPH.reset_all()
+
+
+fn test_forward_3() raises:
+    # padding=3, stride=3,
+    # input shape: (4, 3, 32, 17)  kernel shape: (2, 3, 2, 2)
+    # result_shape:  (4, 2, 13, 8)
+    alias padding = 3
+    alias stride = 3
+    var inputs = Tensor[dtype](4, 3, 32, 17)
+    var kernel = Tensor[dtype](2, 3, 2, 2)
+    fill[dtype, nelts](inputs, 1.0)
+    fill[dtype, nelts](kernel, 1.0)
+    var bias = Tensor[dtype](2)
+    fill[dtype, nelts](bias, 0)
+
+    let res = CONV2D.forward[padding, stride](inputs, kernel, bias)
+    let torch_out = torch_conv2d(
+        inputs, kernel, bias=bias, padding=padding, stride=stride, upper_grad=res.grad
+    )
     assert_tensors_equal(res.tensor, torch_out.expected)
     GRAPH.reset_all()
 
@@ -166,7 +191,7 @@ fn test_backward_1() raises:
     alias in_channels = 2
     alias out_channels = 3
     var inputs = Tensor[dtype](batch, in_channels, 28, 28)
-    var kernel = Tensor[dtype](out_channels, in_channels, 1 , 16)
+    var kernel = Tensor[dtype](out_channels, in_channels, 1, 16)
     fill[dtype, nelts](inputs, 1.0)
     fill[dtype, nelts](kernel, 1.0)
     let bias: Tensor[dtype] = rand[dtype](out_channels)
@@ -177,24 +202,27 @@ fn test_backward_1() raises:
     assert_equal(gn.parents.size, 3)
     let upper_grad: Tensor[dtype] = rand[dtype](res.tensor.shape())
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0) # inputs.grad
-    let ug2 = gn.backward_fn(upper_grad, gn.parents, 1) # kernel.grad
-    let ug3 = gn.backward_fn(upper_grad, gn.parents, 2) # bias.grad
+    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)  # inputs.grad
+    let ug2 = gn.backward_fn(upper_grad, gn.parents, 1)  # kernel.grad
+    let ug3 = gn.backward_fn(upper_grad, gn.parents, 2)  # bias.grad
 
-    let torch_out = torch_conv2d(inputs, kernel, bias=bias, padding=padding, stride=stride, upper_grad=upper_grad)
+    let torch_out = torch_conv2d(
+        inputs, kernel, bias=bias, padding=padding, stride=stride, upper_grad=upper_grad
+    )
     assert_tensors_equal(res.tensor, torch_out.expected)
     assert_tensors_equal(ug1, torch_out.expected_inputs_grad, "almost")
-    assert_tensors_equal(ug2, torch_out.expected_kernel_grad, "almost") 
+    assert_tensors_equal(ug2, torch_out.expected_kernel_grad, "almost")
     assert_tensors_equal(ug3, torch_out.expected_bias_grad, "almost")
     GRAPH.reset_all()
 
 
 fn main():
-
     try:
         test_get_result_shape()
         test_forward_1()
         test_forward_2()
+        test_forward_3()
         test_backward_1()
-    except:
+    except e:
         print("Error")
+        print(e)

--- a/test/test_conv.mojo
+++ b/test/test_conv.mojo
@@ -277,10 +277,10 @@ fn test_backward_1() raises:
 
 
 fn test_backward_2() raises:
-    # padding=(2, 4), stride=(3, 1), dilation=1
+    # padding=(2, 4), stride=(3, 1), dilation=2
     alias padding = StaticIntTuple[2](2, 4)
     alias stride = StaticIntTuple[2](3, 1)
-    alias dilation = 1
+    alias dilation = 2
     alias batch = 4
     alias in_channels = 2
     alias out_channels = 3
@@ -290,7 +290,7 @@ fn test_backward_2() raises:
     fill[dtype, nelts](kernel, 1.0)
     let bias: Tensor[dtype] = rand[dtype](out_channels)
 
-    let res = CONV2D.forward[padding, stride](inputs, kernel, bias)
+    let res = CONV2D.forward[padding, stride, dilation](inputs, kernel, bias)
 
     let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 3)
@@ -317,10 +317,10 @@ fn test_backward_2() raises:
 
 
 fn test_backward_3() raises:
-    # padding=(2, 4), stride=2, dilation=1
+    # padding=(2, 4), stride=2, dilation=(3, 2)
     alias padding = StaticIntTuple[2](3, 2)
     alias stride = 2
-    alias dilation = 1
+    alias dilation = StaticIntTuple[2](3, 2)
     alias batch = 4
     alias in_channels = 2
     alias out_channels = 3
@@ -366,5 +366,5 @@ fn main():
         test_backward_2()
         test_backward_3()
     except e:
-        print("Error")
+        print("[Error] Error in Conv2D")
         print(e)

--- a/test/test_conv.mojo
+++ b/test/test_conv.mojo
@@ -48,7 +48,7 @@ fn test_get_result_shape() raises:
     assert_equal(res[0], 36)
     assert_equal(res[1], 17)
 
-    # padding=(3, 2), stride=(2, 1), dilaiton=(2, 3)
+    # padding=(3, 2), stride=(2, 1), dilation=(2, 3)
     # input shape: (4, 32, 17)  kernel shape: (2, 2)
     # result:  (18, 18)
     inputs = Tensor[dtype](4, 32, 17)

--- a/test/test_conv.mojo
+++ b/test/test_conv.mojo
@@ -46,6 +46,18 @@ fn test_get_result_shape() raises:
     assert_equal(res[0], 37)
     assert_equal(res[1], 18)
 
+    # padding=(3, 2), stride=(2, 1),
+    # input shape: (4, 32, 17)  kernel shape: (2, 2)
+    # result:  (18, 20)
+    inputs = Tensor[dtype](4, 32, 17)
+    kernel = Tensor[dtype](3, 2)
+
+    res = get_result_shape[StaticIntTuple[2](3, 2), StaticIntTuple[2](2, 1)](
+        inputs.shape(), kernel.shape()
+    )
+    assert_equal(res[0], 18)
+    assert_equal(res[1], 20)
+
 
 def to_numpy(tensor: Tensor) -> PythonObject:
     let np = Python.import_module("numpy")

--- a/test/test_conv.mojo
+++ b/test/test_conv.mojo
@@ -16,47 +16,49 @@ alias nelts: Int = simdwidthof[dtype]()
 
 
 fn test_get_result_shape() raises:
-    # padding=2, stride=1
+    # padding=2, stride=1, dilation=1
     # input shape: (4, 28, 28)  kernel shape: (1, 16)
     # result:  (32, 17)
     var inputs = Tensor[dtype](4, 28, 28)
     var kernel = Tensor[dtype](1, 16)
 
-    var res = get_result_shape[2, 1](inputs.shape(), kernel.shape())
+    var res = get_result_shape[2, 1, 1](inputs.shape(), kernel.shape())
     assert_equal(res[0], 32)
     assert_equal(res[1], 17)
 
-    # padding=0, stride=1,
+    # padding=0, stride=1, dilation=1
     # input shape: (4, 32, 17)  kernel shape: (2, 2)
     # result:  (31, 16)
     inputs = Tensor[dtype](4, 32, 17)
     kernel = Tensor[dtype](2, 2)
 
-    res = get_result_shape[0, 1](inputs.shape(), kernel.shape())
+    res = get_result_shape[0, 1, 1](inputs.shape(), kernel.shape())
     assert_equal(res[0], 31)
     assert_equal(res[1], 16)
 
-    # padding=(3, 1), stride=1,
+    # padding=(3, 1), stride=1, dilation=2
     # input shape: (4, 32, 17)  kernel shape: (2, 2)
-    # result:  (37, 18)
+    # result:  (36, 17)
     inputs = Tensor[dtype](4, 32, 17)
     kernel = Tensor[dtype](2, 2)
 
-    res = get_result_shape[StaticIntTuple[2](3, 1), 1](inputs.shape(), kernel.shape())
-    assert_equal(res[0], 37)
-    assert_equal(res[1], 18)
+    res = get_result_shape[StaticIntTuple[2](3, 1), 1, 2](
+        inputs.shape(), kernel.shape()
+    )
+    assert_equal(res[0], 36)
+    assert_equal(res[1], 17)
 
-    # padding=(3, 2), stride=(2, 1),
+    # padding=(3, 2), stride=(2, 1), dilaiton=(2, 3)
     # input shape: (4, 32, 17)  kernel shape: (2, 2)
-    # result:  (18, 20)
+    # result:  (18, 18)
     inputs = Tensor[dtype](4, 32, 17)
     kernel = Tensor[dtype](3, 2)
 
-    res = get_result_shape[StaticIntTuple[2](3, 2), StaticIntTuple[2](2, 1)](
-        inputs.shape(), kernel.shape()
-    )
-    assert_equal(res[0], 18)
-    assert_equal(res[1], 20)
+    res = get_result_shape[
+        StaticIntTuple[2](3, 2), StaticIntTuple[2](2, 1), StaticIntTuple[2](2, 3)
+    ](inputs.shape(), kernel.shape())
+    assert_equal(res[0], 17)
+    assert_equal(res[1], 18)
 
 
 def to_numpy(tensor: Tensor) -> PythonObject:


### PR DESCRIPTION
## This Pull request adds
- Support for different W and H values for padding in Conv2D [**Finished**]
- Edited the get_result_shape function to use // instead of floor and to int, just to make the function a little bit shorter and cleaner (both operations should give the same result) [**Finished**]
- Support for different W and H values for strides in Conv2D [**Finished**]
- Added more tests for Conv2D backward and forward pass [**Finished**]
- Added more tests for get_result_shape for Conv [**Finished**]
- Optimization that removed ifs in Conv2d Forward pass using the MLX Conv2D as an example [**Finished**]
- Added strides for the Tensor (At least while we wait for tensors to have it natively) in Node [**Finished**]
- Changed the operations in Conv2D to now use pre-calculated strides [**Finished**]
- Fixed a bug in the calculation of ix and iy in backward pass of Conv2D for kernel [**Finished**]
- Fixed a bug in the calculation of ux and uy in backward pass of Conv2D for inputs [**Finished?**]
	- The problem for this operations is that the calculation using stride wasn't really considering the stride, sometimes an ix or iy value would act on less ux and uy values than other ix and iy or even not contribute to any ux or uy
	- I fixed this bug by changing how we obtain the positions, instead of getting ux and uy I changed it to instead get ix and iy, I wanted to fix the calculation of ux and uy but I haven't found a way in how to calculate the kx_start and ky_start values. This was the version that I was trying (and kx and ky start is necessary because the formula for ux and uy would give ""*correct results*"" when giving it kx and ky values that the ix and iy values would never touch):
	- ```py
	   var res = Tensor[dtype](inputs.shape())

            for batch in range(inputs.dim(0)):
                for in_ch in range(inputs.dim(1)):
                    for ix in range(inputs.dim(2)):
                        for iy in range(inputs.dim(3)):
                            var result: SIMD[dtype, 1] = 0
                            # fix kx_start and ky_start values
                            let kx_start = (
                                ((ix + padding[0]) * stride[1]) % kernel.dim(2)
                            )
                            let ky_start = (
                                ((iy + padding[1]) * stride[0]) % kernel.dim(3)
                            )
                            for out_ch in range(ug.dim(1)):
                                for kx in range(kx_start, kernel.dim(2), stride[0]):
                                    for ky in range(ky_start, kernel.dim(3), stride[1]):
                                        let ux = (ix - kx + padding[0]) // stride[0]
                                        let uy = (iy - ky + padding[1]) // stride[1]

                                        if (
                                            ux < 0
                                            or uy < 0
                                            or ux >= ug.dim(2)
                                            or uy >= ug.dim(3)
                                        ):
                                            continue

                                        let kernel_index = (
                                            out_ch * kernel_strides[0]
                                            + in_ch * kernel_strides[1]
                                            + kx * kernel_strides[2]
                                            + ky
                                        )

                                        let ug_index = (
                                            batch * ug_strides[0]
                                            + out_ch * ug_strides[1]
                                            + ux * ug_strides[2]
                                            + uy
                                        )

                                        result += kernel[kernel_index] * ug[ug_index]

                            let input_index = (
                                batch * inputs_strides[0]
                                + in_ch * inputs_strides[1]
                                + ix * inputs_strides[2]
                                + iy
                            )
                            res[input_index] = result

            return res```
### New
- Support for Dilation [**Finished**]
- Propagate changes to Conv2D Layer [**Finished**]