### PR TITLE
Fix library to be able to run in mojo v0.7.0

### DIFF
--- a/dainemo/nn/layers/sequential.mojo
+++ b/dainemo/nn/layers/sequential.mojo
@@ -9,8 +9,8 @@ struct Sequential[dtype: DType]:
 
     var layers: VariadicList[AnyType]
 
-    fn __init__(inout self, *layers: AnyType):
-        self.layers = layers
+    # fn __init__(inout self, *layers: AnyType):
+    #     self.layers = layers
 
     # fn forward(inout self, inputs: Tensor[dtype]):
     #     for i in range(self.layers.__len__()):

--- a/dainemo/utils/tensorutils.mojo
+++ b/dainemo/utils/tensorutils.mojo
@@ -591,9 +591,9 @@ fn broadcast_shapes(s1: TensorShape, s2: TensorShape) raises -> TensorShape:
 
 @always_inline
 fn broadcast_shapes(*s: TensorShape) raises -> TensorShape:
-    var result_shape = __get_address_as_lvalue(s[0])
+    var result_shape = s[0]
 
     for i in range(1, len(s)):
-        result_shape = broadcast_shapes(result_shape, __get_address_as_lvalue(s[i]))
+        result_shape = broadcast_shapes(result_shape, s[i])
 
     return result_shape


### PR DESCRIPTION
# Small fix to be able to run the library in mojo v0.7.0

## What was fixed:
Now if you want a function that can accept a VariadicListMem or the new Reference you need the syntax (for now):
```py
fn foos[lifetime: ImmLifetime](args: VariadicListMem[String, __mlir_attr.`false`, lifetime]):
    pass

fn bar(borrowed *args: String):
    foos(args)

fn main():
    var a = "hello"
    bar(a)
```
This are the attributes:
- type (AnyType): Type of the underlying data.
- ​is_mutable (i1): Whether the referenced data may be mutated through this.
- lifetime (lifetime<is_mutable>): The lifetime of the reference.

So the first one tells us the type, the second one if its mutable (but using mlir instead of mojo types) and the third one I think refers to the lifetime of the value (also saying if its mutable or not) like in rust (`a). So for now it is very verbose

And also remove the use of __get_addres_as_lvalue because it is not necessary anymore.