### PR TITLE
Update for Mojo 24.1

### DIFF
--- a/dainemo/autograd/graph.mojo
+++ b/dainemo/autograd/graph.mojo
@@ -173,7 +173,7 @@ struct Graph[dtype: DType = DType.float32, tracking: Bool = True](Stringable):
         """
         Marks the Node corresponding to the given uuid as visited in the graph.
         """
-        let idx = self.get_node_idx(node_uuid)
+        var idx = self.get_node_idx(node_uuid)
         if idx != -1:
             # TODO: self.graph[idx].visited = True
             # Lifetimes (__getitem__ of a dynamic vector returns a copy and not a reference)

--- a/dainemo/autograd/node.mojo
+++ b/dainemo/autograd/node.mojo
@@ -98,7 +98,7 @@ struct Node[dtype: DType = DType.float32](CollectionElement, Stringable):
         Checks if all children of the node are visited in the graph.
         """
         for i in range(self.children.size):
-            let idx = GRAPH.get_node_idx(self.children[i])
+            var idx = GRAPH.get_node_idx(self.children[i])
             if not GRAPH.graph[idx].visited:
                 return False
         return True
@@ -108,7 +108,7 @@ struct Node[dtype: DType = DType.float32](CollectionElement, Stringable):
         Checks if all parents of the node are visited in the graph.
         """
         for i in range(self.parents.size):
-            let idx = GRAPH.get_node_idx(self.parents[i])
+            var idx = GRAPH.get_node_idx(self.parents[i])
             if not GRAPH.graph[idx].visited:
                 return False
         return True
@@ -161,7 +161,7 @@ struct Node[dtype: DType = DType.float32](CollectionElement, Stringable):
         """
         # TODO: self.grad = elwise_op[dtype, nelts, add](self.grad, grad) --> only
         # Lifetimes (__getitem__ of a dynamic vector returns a copy and not a reference)
-        let my_idx = GRAPH.get_node_idx(self.uuid)
+        var my_idx = GRAPH.get_node_idx(self.uuid)
         var my_node = GRAPH.graph[my_idx]
         # BUG: my_node.grad has type DType.float32 instead of a generic dtype (also see unbroadcast_data)
         # should be: my_node.grad = elwise_op[dtype, nelts, add](my_node.grad, grad)
@@ -171,7 +171,7 @@ struct Node[dtype: DType = DType.float32](CollectionElement, Stringable):
 
     fn accumulate_grad2(inout self, grad: Tensor[DType.float32]):
         # BUG: overload as workaround: should be one generic dtype
-        let my_idx = GRAPH.get_node_idx(self.uuid)
+        var my_idx = GRAPH.get_node_idx(self.uuid)
         var my_node = GRAPH.graph[my_idx]
         alias nelts: Int = simdwidthof[DType.float32]()
         my_node.grad = elwise_op[DType.float32, nelts, add](my_node.grad, grad)
@@ -183,8 +183,8 @@ struct Node[dtype: DType = DType.float32](CollectionElement, Stringable):
         """
 
         for c in range(self.children.size):
-            let child_idx = GRAPH.get_node_idx(self.children[c])
-            let child = GRAPH.graph[child_idx]
+            var child_idx = GRAPH.get_node_idx(self.children[c])
+            var child = GRAPH.graph[child_idx]
             if self.requires_grad and calculate_grads:
                 # Identify the index of itself in the child.parents NodeCollection
                 # Required when operation has multiple operands to identify the correct gradient function
@@ -226,7 +226,7 @@ struct Node[dtype: DType = DType.float32](CollectionElement, Stringable):
         # 1. If not, topological sort on the children
         if not self.are_children_visited():
             for c in range(self.children.size):
-                let idx = GRAPH.get_node_idx(self.children[c])
+                var idx = GRAPH.get_node_idx(self.children[c])
                 var child = GRAPH.graph[idx]
                 if not child.visited:
                     child.topological_sort(sorted_nodes)
@@ -237,7 +237,7 @@ struct Node[dtype: DType = DType.float32](CollectionElement, Stringable):
             GRAPH.mark_visited(self.uuid)
             sorted_nodes.push_back(self.uuid)
             for p in range(self.parents.size):
-                let idx = GRAPH.get_node_idx(self.parents[p])
+                var idx = GRAPH.get_node_idx(self.parents[p])
                 var parent = GRAPH.graph[idx]
                 if not parent.visited:
                     parent.topological_sort(sorted_nodes)

--- a/dainemo/autograd/ops/basics.mojo
+++ b/dainemo/autograd/ops/basics.mojo
@@ -26,13 +26,13 @@ struct ADD:
     @staticmethod
     fn forward(n1: Node[dtype], n2: Node[dtype]) -> Node[dtype]:
         """Forward operation of element wise addition."""
-        let res = elwise_op[dtype, nelts, add](n1.tensor, n2.tensor)
+        var res = elwise_op[dtype, nelts, add](n1.tensor, n2.tensor)
         return GRAPH.create_graph_node[Self.backward](res, n1, n2)
 
     @staticmethod
     fn forward(n1: Node[dtype], a: SIMD[dtype, 1]) -> Node[dtype]:
         """Forward operation of tensor-scalar addition."""
-        let res: Tensor[dtype] = elwise_op[dtype, nelts, add](n1.tensor, a)
+        var res: Tensor[dtype] = elwise_op[dtype, nelts, add](n1.tensor, a)
         var a_tensor: Tensor[dtype] = Tensor[dtype](1)
         a_tensor[0] = a
         return GRAPH.create_graph_node[Self.backward](res, n1, Node[dtype](a_tensor))
@@ -51,7 +51,7 @@ struct SUB:
     @staticmethod
     fn forward(n1: Node[dtype], n2: Node[dtype]) -> Node[dtype]:
         """Forward operation of element wise subtraction."""
-        let res = elwise_op[dtype, nelts, sub](n1.tensor, n2.tensor)
+        var res = elwise_op[dtype, nelts, sub](n1.tensor, n2.tensor)
         return GRAPH.create_graph_node[Self.backward](res, n1, n2)
 
     @staticmethod
@@ -64,7 +64,7 @@ struct SUB:
             return ug
         else:
             # d(x - y) / dy = -1
-            let factor: SIMD[dtype, 1] = -1.0
+            var factor: SIMD[dtype, 1] = -1.0
             return elwise_op[dtype, nelts, mul](factor, ug)
 
 
@@ -73,13 +73,13 @@ struct MUL:
     @staticmethod
     fn forward(n1: Node[dtype], n2: Node[dtype]) -> Node[dtype]:
         """Forward operation of element wise multiplication."""
-        let res = elwise_op[dtype, nelts, mul](n1.tensor, n2.tensor)
+        var res = elwise_op[dtype, nelts, mul](n1.tensor, n2.tensor)
         return GRAPH.create_graph_node[Self.backward](res, n1, n2)
 
     @staticmethod
     fn forward(n1: Node[dtype], a: SIMD[dtype, 1]) -> Node[dtype]:
         """Forward operation of tensor-scalar multiplication."""
-        let res: Tensor[dtype] = elwise_op[dtype, nelts, mul](n1.tensor, a)
+        var res: Tensor[dtype] = elwise_op[dtype, nelts, mul](n1.tensor, a)
         var a_tensor: Tensor[dtype] = Tensor[dtype](1)
         a_tensor[0] = a
         return GRAPH.create_graph_node[Self.backward](res, n1, Node[dtype](a_tensor))
@@ -91,8 +91,8 @@ struct MUL:
         """Backward operation of element wise multiplication."""
         # d(x*y) / dx = y
         # d(x*y) / dy = x
-        let other_id: Int = (tensor_id + 1) % 2
-        let other_node = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[other_id])]
+        var other_id: Int = (tensor_id + 1) % 2
+        var other_node = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[other_id])]
         return elwise_op[dtype, nelts, mul](other_node.tensor, ug)
 
 
@@ -101,13 +101,13 @@ struct DIV:
     @staticmethod
     fn forward(n1: Node[dtype], n2: Node[dtype]) -> Node[dtype]:
         """Forward operation of element wise division."""
-        let res = elwise_op[dtype, nelts, div](n1.tensor, n2.tensor)
+        var res = elwise_op[dtype, nelts, div](n1.tensor, n2.tensor)
         return GRAPH.create_graph_node[Self.backward](res, n1, n2)
 
     @staticmethod
     fn forward(n1: Node[dtype], a: SIMD[dtype, 1]) -> Node[dtype]:
         """Forward operation of tensor-scalar division."""
-        let res: Tensor[dtype] = elwise_op[dtype, nelts, div](n1.tensor, a)
+        var res: Tensor[dtype] = elwise_op[dtype, nelts, div](n1.tensor, a)
         var a_tensor: Tensor[dtype] = Tensor[dtype](1)
         a_tensor[0] = a
         return GRAPH.create_graph_node[Self.backward](res, n1, Node[dtype](a_tensor))
@@ -120,15 +120,15 @@ struct DIV:
         # d(x/y) / dx = 1/y
         # d(x/y) / dy = -x/y^2
         if tensor_id == 0:
-            let n2 = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[1])]
-            let res = elwise_op[dtype, nelts, div](1.0, n2.tensor)
+            var n2 = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[1])]
+            var res = elwise_op[dtype, nelts, div](1.0, n2.tensor)
             return elwise_op[dtype, nelts, mul](res, ug)
         else:
-            let n1 = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])]
-            let n2 = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[1])]
-            let n2_sq = elwise_pow[dtype, nelts](n2.tensor, 2)
-            let div_n1_n2_sq = elwise_op[dtype, nelts, div](n1.tensor, n2_sq)
-            let res = elwise_op[dtype, nelts, mul](div_n1_n2_sq, -1.0)
+            var n1 = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])]
+            var n2 = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[1])]
+            var n2_sq = elwise_pow[dtype, nelts](n2.tensor, 2)
+            var div_n1_n2_sq = elwise_op[dtype, nelts, div](n1.tensor, n2_sq)
+            var res = elwise_op[dtype, nelts, mul](div_n1_n2_sq, -1.0)
             return elwise_op[dtype, nelts, mul](res, ug)
 
 
@@ -137,7 +137,7 @@ struct DOT:
     @staticmethod
     fn forward(n1: Node[dtype], n2: Node[dtype]) -> Node[dtype]:
         """Forward operation of dot product."""
-        let res: Tensor[dtype] = dot[dtype, nelts](n1.tensor, n2.tensor)
+        var res: Tensor[dtype] = dot[dtype, nelts](n1.tensor, n2.tensor)
         return GRAPH.create_graph_node[Self.backward](res, n1, n2)
 
     @staticmethod
@@ -146,12 +146,12 @@ struct DOT:
     ) -> Tensor[dtype]:
         """Backward operation of dot product."""
         if tensor_id == 0:
-            let n2 = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[1])]
+            var n2 = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[1])]
             return dot[dtype, nelts](
                 ug, transpose[dtype, nelts](n2.tensor)
             )  # dot(ug, n2.T)
         else:
-            let n1 = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])]
+            var n1 = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])]
             return dot[dtype, nelts](
                 transpose[dtype, nelts](n1.tensor), ug
             )  # dot(n1.T, ug)
@@ -162,7 +162,7 @@ struct EXP:
     @staticmethod
     fn forward(n: Node[dtype]) -> Node[dtype]:
         """Forward operation of exp."""
-        let res: Tensor[dtype] = elwise_transform[dtype, nelts, exp](n.tensor)
+        var res: Tensor[dtype] = elwise_transform[dtype, nelts, exp](n.tensor)
         return GRAPH.create_graph_node[Self.backward](res, n)
 
     @staticmethod
@@ -171,8 +171,8 @@ struct EXP:
     ) -> Tensor[dtype]:
         """Backward operation of exp."""
         # d(exp(x)) / dx = exp(x)
-        let t = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor
-        let res = elwise_transform[dtype, nelts, exp](t)
+        var t = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor
+        var res = elwise_transform[dtype, nelts, exp](t)
         return elwise_op[dtype, nelts, mul](res, ug)
 
 
@@ -181,7 +181,7 @@ struct LOG:
     @staticmethod
     fn forward(n: Node[dtype]) -> Node[dtype]:
         """Forward operation of log."""
-        let res: Tensor[dtype] = elwise_transform[dtype, nelts, log](n.tensor)
+        var res: Tensor[dtype] = elwise_transform[dtype, nelts, log](n.tensor)
         return GRAPH.create_graph_node[Self.backward](res, n)
 
     @staticmethod
@@ -190,8 +190,8 @@ struct LOG:
     ) -> Tensor[dtype]:
         """Backward operation of log."""
         # d(log(x)) / dx = 1 / x
-        let t = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor
-        let res = elwise_op[dtype, nelts, div](1.0, t)
+        var t = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor
+        var res = elwise_op[dtype, nelts, div](1.0, t)
         return elwise_op[dtype, nelts, mul](res, ug)
 
 
@@ -200,7 +200,7 @@ struct POW:
     @staticmethod
     fn forward(n1: Node[dtype], a: Int) -> Node[dtype]:
         """Forward operation of element wise pow."""
-        let res: Tensor[dtype] = elwise_pow[dtype, nelts](n1.tensor, a)
+        var res: Tensor[dtype] = elwise_pow[dtype, nelts](n1.tensor, a)
         var a_tensor: Tensor[dtype] = Tensor[dtype](1)
         a_tensor[0] = a
         return GRAPH.create_graph_node[Self.backward](res, n1, Node[dtype](a_tensor))
@@ -211,20 +211,20 @@ struct POW:
     ) -> Tensor[dtype]:
         """Backward operation of element wise pow."""
         # By design: tensor has id = 0 and scalar has id 1
-        let a: SIMD[dtype, 1] = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[1])].tensor[0]
-        let t = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor
+        var a: SIMD[dtype, 1] = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[1])].tensor[0]
+        var t = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor
 
         if tensor_id == 0:
             # d(x^y) / dx = y * x^(y-1)
-            let res = elwise_op[dtype, nelts, mul](
+            var res = elwise_op[dtype, nelts, mul](
                 a, elwise_pow[dtype, nelts](t, a.to_int() - 1)
             )  # a * t^(a-1)
             return elwise_op[dtype, nelts, mul](res, ug)  # a * t^(a-1) * ug
         else:
             # d(x^y) / dy = x^y * log(x)
-            let t_a = elwise_pow[dtype, nelts](t, a.to_int())  # t^a
-            let log_t = elwise_transform[dtype, nelts, log](t)  # log(t)
-            let res = elwise_op[dtype, nelts, mul](t_a, log_t)  # t^a * log(t)
+            var t_a = elwise_pow[dtype, nelts](t, a.to_int())  # t^a
+            var log_t = elwise_transform[dtype, nelts, log](t)  # log(t)
+            var res = elwise_op[dtype, nelts, mul](t_a, log_t)  # t^a * log(t)
             return elwise_op[dtype, nelts, mul](res, ug)  # t^a * log(t) * ug
 
 
@@ -233,13 +233,13 @@ struct SUM:
     @staticmethod
     fn forward[axis: Int](n: Node[dtype]) -> Node[dtype]:
         """Forward pass of sum operation: along axis."""
-        let res: Tensor[dtype] = tsum[dtype, nelts](n.tensor, axis=axis)
+        var res: Tensor[dtype] = tsum[dtype, nelts](n.tensor, axis=axis)
         return GRAPH.create_graph_node[Self.backward[axis=axis]](res, n)
 
     @staticmethod
     fn forward(n: Node[dtype]) -> Node[dtype]:
         """Forward pass of sum operation: all elements."""
-        let res: SIMD[dtype, 1] = tsum[dtype, nelts](n.tensor)
+        var res: SIMD[dtype, 1] = tsum[dtype, nelts](n.tensor)
         var res_tensor = Tensor[dtype](1)
         res_tensor[0] = res
         return GRAPH.create_graph_node[Self.backward[axis=-1]](res_tensor, n)
@@ -252,7 +252,7 @@ struct SUM:
     ]:
         """Backward pass of sum operation."""
         # Expand the upper gradient to the same shape as the input tensor
-        let t = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor
+        var t = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor
         var res = Tensor[dtype](t.shape())
         fill[dtype, nelts](res, 1.0)
 
@@ -265,14 +265,14 @@ struct MAX:
     fn forward[axis: Int](n: Node[dtype]) -> Node[dtype]:
         """Forward pass of max operation: along axis."""
         alias nelts: Int = simdwidthof[dtype]()
-        let res: Tensor[dtype] = tmax[dtype, nelts](n.tensor, axis=axis)
+        var res: Tensor[dtype] = tmax[dtype, nelts](n.tensor, axis=axis)
         return GRAPH.create_graph_node[Self.backward[axis=axis]](res, n)
 
     @staticmethod
     fn forward(n: Node[dtype]) -> Node[dtype]:
         """Forward pass of max operation: all elements."""
         alias nelts: Int = simdwidthof[dtype]()
-        let res: SIMD[dtype, 1] = tmax[dtype, nelts](n.tensor)
+        var res: SIMD[dtype, 1] = tmax[dtype, nelts](n.tensor)
         var res_tensor = Tensor[dtype](1)
         res_tensor[0] = res
         return GRAPH.create_graph_node[Self.backward[axis= -1]](res_tensor, n)
@@ -293,43 +293,43 @@ struct MAX:
         # multiple max values, the gradient is divided by the number of max
         # values (1/n) for each max value.
         alias nelts: Int = simdwidthof[dtype]()
-        let t_node = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])]
-        let t = t_node.tensor
-        let strides = calculate_strides(t.shape())
+        var t_node = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])]
+        var t = t_node.tensor
+        var strides = calculate_strides(t.shape())
         var res = Tensor[dtype](t.shape())
 
         @parameter
         if axis == -1:
             # ug size is 1
-            let max_res = tmax[dtype, nelts](t)
+            var max_res = tmax[dtype, nelts](t)
             var sum_eq: SIMD[dtype, 1] = 0
             for i in range(t.num_elements()):
                 if t[i] == max_res:
                     sum_eq += 1
 
-            let factor = 1 / sum_eq
+            var factor = 1 / sum_eq
             for i in range(res.num_elements()):
                 if t[i] == max_res:
                     res[i] = factor * ug[0]
         else:
             # max_res.shape == ug.shape
-            let max_res = tmax[dtype, nelts](t, axis=axis)
+            var max_res = tmax[dtype, nelts](t, axis=axis)
 
             for i in range(max_res.num_elements()):
-                let index_base = (i % strides[axis]) + (i // strides[axis]) * (
+                var index_base = (i % strides[axis]) + (i // strides[axis]) * (
                     strides[axis] * t.dim(axis)
                 )
 
                 var count_1s: SIMD[dtype, 1] = 0
                 # Count the number of values equal to max_res
                 for j in range(t.dim(axis)):
-                    let index = index_base + j * strides[axis]
+                    var index = index_base + j * strides[axis]
                     if t[index] == max_res[i]:
                         count_1s += 1
                 # Divide 1.0 by the number of max values (n) and multiply by upper gradient value
-                let factor = 1 / count_1s
+                var factor = 1 / count_1s
                 for j in range(t.dim(axis)):
-                    let index = index_base + j * strides[axis]
+                    var index = index_base + j * strides[axis]
                     if t[index] == max_res[i]:
                         res[index] = factor * ug[i]
 
@@ -341,7 +341,7 @@ struct TRANSPOSE:
     @staticmethod
     fn forward(n: Node[dtype]) -> Node[dtype]:
         """Forward pass of transpose operation."""
-        let res = transpose[dtype, nelts](n.tensor)
+        var res = transpose[dtype, nelts](n.tensor)
         return GRAPH.create_graph_node[Self.backward](res, n)
 
     @staticmethod
@@ -372,7 +372,7 @@ struct FLATTEN:
         Reshape upper gradient to original shape.
         """
         var res = ug
-        let shape = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor.shape()
+        var shape = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor.shape()
 
         try:
             res.ireshape(shape)
@@ -402,7 +402,7 @@ struct RESHAPE:
         Reshape upper gradient to original shape.
         """
         var res = ug
-        let shape = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor.shape()
+        var shape = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor.shape()
 
         try:
             res.ireshape(shape)

--- a/dainemo/autograd/ops/conv.mojo
+++ b/dainemo/autograd/ops/conv.mojo
@@ -18,11 +18,11 @@ fn get_result_shape[
         dimension Y on index -1.
     """
 
-    let result_x_dim = (
+    var result_x_dim = (
         (input_shape[-2] + (2 * padding[0]) - dilation[0] * (kernel_shape[-2] - 1) - 1)
         // stride[0]
     ) + 1
-    let result_y_dim = (
+    var result_y_dim = (
         (input_shape[-1] + (2 * padding[1]) - dilation[1] * (kernel_shape[-1] - 1) - 1)
         // stride[1]
     ) + 1
@@ -46,7 +46,7 @@ struct CONV2D:
             output.shape     [batch, out_channels, oX, oY].
         """
 
-        let result_shape = get_result_shape[padding, stride, dilation](
+        var result_shape = get_result_shape[padding, stride, dilation](
             inputs.tensor.shape(), kernel.tensor.shape()
         )
 
@@ -61,13 +61,13 @@ struct CONV2D:
         ](batch: Int, out_ch: Int, x: Int, y: Int):
             var result: SIMD[dtype, 1] = 0
 
-            let ix_base = x * stride[0] - padding[0]
-            let iy_base = y * stride[1] - padding[1]
+            var ix_base = x * stride[0] - padding[0]
+            var iy_base = y * stride[1] - padding[1]
             for in_ch in range(inputs.tensor.dim(1)):
                 for kx in range(kernel.tensor.dim(2)):
                     for ky in range(kernel.tensor.dim(3)):
-                        let ix = ix_base + kx * dilation[0]
-                        let iy = iy_base + ky * dilation[1]
+                        var ix = ix_base + kx * dilation[0]
+                        var iy = iy_base + ky * dilation[1]
 
                         @parameter
                         if all_checks:
@@ -79,14 +79,14 @@ struct CONV2D:
                             ):
                                 continue
 
-                        let kernel_index = (
+                        var kernel_index = (
                             out_ch * kernel.strides[0]
                             + in_ch * kernel.strides[1]
                             + kx * kernel.strides[2]
                             + ky
                         )
 
-                        let input_index = (
+                        var input_index = (
                             batch * inputs.strides[0]
                             + in_ch * inputs.strides[1]
                             + ix * inputs.strides[2]
@@ -97,7 +97,7 @@ struct CONV2D:
                             inputs.tensor[input_index] * kernel.tensor[kernel_index]
                         )
 
-            let output_index = (
+            var output_index = (
                 batch * outputs_strides[0]
                 + out_ch * outputs_strides[1]
                 + x * outputs_strides[2]
@@ -106,24 +106,24 @@ struct CONV2D:
 
             outputs[output_index] = result + bias.tensor[out_ch]
 
-        let oH_border_0 = 0
-        let oH_border_1 = (padding[0] + stride[0] + 1) // stride[0]
-        let oH_border_2 = (
+        var oH_border_0 = 0
+        var oH_border_1 = (padding[0] + stride[0] + 1) // stride[0]
+        var oH_border_2 = (
             inputs.tensor.dim(2) + padding[0] - kernel.tensor.dim(2) * dilation[0]
         ) // stride[0]
-        let oH_border_3 = outputs.dim(2)
+        var oH_border_3 = outputs.dim(2)
 
-        let oW_border_0 = 0
-        let oW_border_1 = (padding[1] + stride[0] + 1) // stride[1]
-        let oW_border_2 = (
+        var oW_border_0 = 0
+        var oW_border_1 = (padding[1] + stride[0] + 1) // stride[1]
+        var oW_border_2 = (
             inputs.tensor.dim(3) + padding[1] - kernel.tensor.dim(3) * dilation[1]
         ) // stride[1]
-        let oW_border_3 = outputs.dim(3)
+        var oW_border_3 = outputs.dim(3)
 
         for batch in range(inputs.tensor.dim(0)):
             for out_ch in range(outputs.dim(1)):
-                let batch_o_idx = batch * outputs_strides[0]
-                let out_ch_o_idx = out_ch * outputs_strides[1]
+                var batch_o_idx = batch * outputs_strides[0]
+                var out_ch_o_idx = out_ch * outputs_strides[1]
                 # Case 1: oh might put us out of bounds
                 for x in range(oH_border_0, oH_border_1):
                     for y in range(outputs.dim(3)):
@@ -162,14 +162,14 @@ struct CONV2D:
         Upper gradient of shape: [batch, out_channels, uX, uY].
         """
 
-        let inputs = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor
-        let inputs_strides = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].strides
-        let kernel = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[1])].tensor
-        let kernel_strides = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[1])].strides
-        let bias = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[2])].tensor
-        let bias_strides = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[2])].strides
+        var inputs = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor
+        var inputs_strides = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].strides
+        var kernel = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[1])].tensor
+        var kernel_strides = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[1])].strides
+        var bias = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[2])].tensor
+        var bias_strides = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[2])].strides
 
-        let ug_strides = calculate_strides(ug.shape())
+        var ug_strides = calculate_strides(ug.shape())
 
         if tensor_id == 0:
             # Inputs
@@ -179,13 +179,13 @@ struct CONV2D:
                 for out_ch in range(ug.dim(1)):
                     for ux in range(ug.dim(2)):
                         for uy in range(ug.dim(3)):
-                            let ix_base = ux * stride[0] - padding[0]
-                            let iy_base = uy * stride[1] - padding[1]
+                            var ix_base = ux * stride[0] - padding[0]
+                            var iy_base = uy * stride[1] - padding[1]
                             for in_ch in range(inputs.dim(1)):
                                 for kx in range(kernel.dim(2)):
                                     for ky in range(kernel.dim(3)):
-                                        let ix = ix_base + kx * dilation[0]
-                                        let iy = iy_base + ky * dilation[1]
+                                        var ix = ix_base + kx * dilation[0]
+                                        var iy = iy_base + ky * dilation[1]
 
                                         if (
                                             ix < 0
@@ -195,21 +195,21 @@ struct CONV2D:
                                         ):
                                             continue
 
-                                        let kernel_index = (
+                                        var kernel_index = (
                                             out_ch * kernel_strides[0]
                                             + in_ch * kernel_strides[1]
                                             + kx * kernel_strides[2]
                                             + ky
                                         )
 
-                                        let ug_index = (
+                                        var ug_index = (
                                             batch * ug_strides[0]
                                             + out_ch * ug_strides[1]
                                             + ux * ug_strides[2]
                                             + uy
                                         )
 
-                                        let input_index = (
+                                        var input_index = (
                                             batch * inputs_strides[0]
                                             + in_ch * inputs_strides[1]
                                             + ix * inputs_strides[2]
@@ -233,10 +233,10 @@ struct CONV2D:
                             for batch in range(inputs.dim(0)):
                                 for ux in range(ug.dim(2)):
                                     for uy in range(ug.dim(3)):
-                                        let ix = ux * stride[0] - padding[
+                                        var ix = ux * stride[0] - padding[
                                             0
                                         ] + kx * dilation[0]
-                                        let iy = uy * stride[1] - padding[
+                                        var iy = uy * stride[1] - padding[
                                             1
                                         ] + ky * dilation[1]
 
@@ -248,14 +248,14 @@ struct CONV2D:
                                         ):
                                             continue
 
-                                        let input_index = (
+                                        var input_index = (
                                             batch * inputs_strides[0]
                                             + in_ch * inputs_strides[1]
                                             + ix * inputs_strides[2]
                                             + iy
                                         )
 
-                                        let ug_index = (
+                                        var ug_index = (
                                             batch * ug_strides[0]
                                             + out_ch * ug_strides[1]
                                             + ux * ug_strides[2]
@@ -264,7 +264,7 @@ struct CONV2D:
 
                                         result += inputs[input_index] * ug[ug_index]
 
-                            let kernel_index = (
+                            var kernel_index = (
                                 out_ch * kernel_strides[0]
                                 + in_ch * kernel_strides[1]
                                 + kx * kernel_strides[2]
@@ -285,7 +285,7 @@ struct CONV2D:
                 for batch in range(ug.dim(0)):
                     for ux in range(ug.dim(2)):
                         for uy in range(ug.dim(3)):
-                            let ug_index = (
+                            var ug_index = (
                                 batch * ug_strides[0]
                                 + out_ch * ug_strides[1]
                                 + ux * ug_strides[2]

--- a/dainemo/autograd/ops/mlops.mojo
+++ b/dainemo/autograd/ops/mlops.mojo
@@ -26,7 +26,7 @@ struct SIGMOID:
     @staticmethod
     fn forward(n: Node[dtype]) -> Node[dtype]:
         """Forward operation of sigmoid."""
-        let res: Tensor[dtype] = elwise_transform[dtype, nelts, SIGMOID.sigmoid](
+        var res: Tensor[dtype] = elwise_transform[dtype, nelts, SIGMOID.sigmoid](
             n.tensor
         )
         return GRAPH.create_graph_node[Self.backward](res, n)
@@ -37,13 +37,13 @@ struct SIGMOID:
     ) -> Tensor[dtype]:
         """Backward operation of sigmoid."""
         # d(sigmod(x))/dx = sigmoid(x) * (1 - sigmoid(x))
-        let t = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor
+        var t = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor
         # sigmoid(x)
-        let sigmoid_res = elwise_transform[dtype, nelts, SIGMOID.sigmoid](t)
+        var sigmoid_res = elwise_transform[dtype, nelts, SIGMOID.sigmoid](t)
         # 1 - sigmoid(x)
-        let sub_res = elwise_op[dtype, nelts, sub](SIMD[dtype, 1](1), sigmoid_res)
+        var sub_res = elwise_op[dtype, nelts, sub](SIMD[dtype, 1](1), sigmoid_res)
         # sigmoid(x) * (1 - sigmoid(x))
-        let res = elwise_op[dtype, nelts, mul](sigmoid_res, sub_res)
+        var res = elwise_op[dtype, nelts, mul](sigmoid_res, sub_res)
 
         return elwise_op[dtype, nelts, mul](ug, res)
 
@@ -53,7 +53,7 @@ struct RELU:
     @staticmethod
     fn forward(n: Node[dtype]) -> Node[dtype]:
         """Forward operation of relu."""
-        let res: Tensor[dtype] = elwise_op[dtype, nelts, max](
+        var res: Tensor[dtype] = elwise_op[dtype, nelts, max](
             n.tensor, SIMD[dtype, 1](0)
         )
         return GRAPH.create_graph_node[Self.backward](res, n)
@@ -70,8 +70,8 @@ struct RELU:
     ) -> Tensor[dtype]:
         """Backward operation of relu."""
         # d(relu(x))/dx = 1 if x > 0 else 0. We also give 0 to x = 0 instead of undefined.
-        let t = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor
-        let res = elwise_transform[dtype, nelts, RELU.relu_derivative](t)
+        var t = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor
+        var res = elwise_transform[dtype, nelts, RELU.relu_derivative](t)
 
         return elwise_op[dtype, nelts, mul](ug, res)
 
@@ -87,7 +87,7 @@ struct TANH:
     @staticmethod
     fn forward(n: Node[dtype]) -> Node[dtype]:
         """Forward operation of tanh."""
-        let res: Tensor[dtype] = elwise_transform[dtype, nelts, TANH.tanh](n.tensor)
+        var res: Tensor[dtype] = elwise_transform[dtype, nelts, TANH.tanh](n.tensor)
         return GRAPH.create_graph_node[Self.backward](res, n)
 
     @staticmethod
@@ -96,10 +96,10 @@ struct TANH:
     ) -> Tensor[dtype]:
         """Backward operation of tanh."""
         # d(tanh(x))/dx = 1 - tanh(x) ** 2
-        let t = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor
-        let tanh_res = elwise_transform[dtype, nelts, TANH.tanh](t)
-        let tanh_res_square = elwise_op[dtype, nelts, mul](tanh_res, tanh_res)
-        let res = elwise_op[dtype, nelts, sub](SIMD[dtype, 1](1), tanh_res_square)
+        var t = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor
+        var tanh_res = elwise_transform[dtype, nelts, TANH.tanh](t)
+        var tanh_res_square = elwise_op[dtype, nelts, mul](tanh_res, tanh_res)
+        var res = elwise_op[dtype, nelts, sub](SIMD[dtype, 1](1), tanh_res_square)
 
         return elwise_op[dtype, nelts, mul](ug, res)
 
@@ -109,12 +109,12 @@ struct SOFTMAX:
     fn softmax[axis: Int](n: Tensor[dtype]) -> Tensor[dtype]:
         """Softmax operation."""
         # exp(x_i - max(x_j)) / sum(exp(x_j))
-        let max_val = tmax[dtype, nelts](n, axis)
-        let x_minus_max = elwise_op[dtype, nelts, sub](n, max_val)
+        var max_val = tmax[dtype, nelts](n, axis)
+        var x_minus_max = elwise_op[dtype, nelts, sub](n, max_val)
 
-        let exp_res = elwise_transform[dtype, nelts, exp](x_minus_max)
-        let sum_res = tsum[dtype, nelts](exp_res, axis)
-        let res = elwise_op[dtype, nelts, div](exp_res, sum_res)
+        var exp_res = elwise_transform[dtype, nelts, exp](x_minus_max)
+        var sum_res = tsum[dtype, nelts](exp_res, axis)
+        var res = elwise_op[dtype, nelts, div](exp_res, sum_res)
 
         return res
 
@@ -123,8 +123,8 @@ struct SOFTMAX:
         """Forward operation of softmax."""
         # softmax: exp(x_i) / sum(exp(x_j))
         # stable softmax: exp(x_i - max(x_j)) / sum(exp(x_j))
-        let softmax_res = Self.softmax[axis](n.tensor)
-        let res = elwise_op[dtype, nelts, div](n.tensor, softmax_res)
+        var softmax_res = Self.softmax[axis](n.tensor)
+        var res = elwise_op[dtype, nelts, div](n.tensor, softmax_res)
 
         return GRAPH.create_graph_node[Self.backward[axis]](res, n)
 

--- a/dainemo/autograd/ops/pool.mojo
+++ b/dainemo/autograd/ops/pool.mojo
@@ -27,26 +27,26 @@ struct MAXPOOL2D:
 
         alias nelts: Int = simdwidthof[dtype]()
         
-        let result_shape = get_result_shape[padding, stride, dilation](
+        var result_shape = get_result_shape[padding, stride, dilation](
             inputs.tensor.shape(), TensorShape(-1, -1, kernel_size[0], kernel_size[1])
         )
 
         var outputs = Tensor[dtype](
             inputs.tensor.dim(0), inputs.tensor.shape()[1], result_shape[0], result_shape[1]
         )
-        let outputs_strides = calculate_strides(outputs.shape())
+        var outputs_strides = calculate_strides(outputs.shape())
 
         for batch in range(inputs.tensor.dim(0)):
             for in_ch in range(inputs.tensor.dim(1)):
                 for x in range(outputs.dim(2)):
                     for y in range(outputs.dim(3)):
                         var max_val: SIMD[dtype, 1] = neginf[dtype]()
-                        let ix_base = x * stride[0] - padding[0]
-                        let iy_base = y * stride[1] - padding[1]
+                        var ix_base = x * stride[0] - padding[0]
+                        var iy_base = y * stride[1] - padding[1]
                         for kx in range(kernel_size[0]):
                             for ky in range(kernel_size[1]):
-                                let ix = ix_base + kx * dilation[0]
-                                let iy = iy_base + ky * dilation[1]
+                                var ix = ix_base + kx * dilation[0]
+                                var iy = iy_base + ky * dilation[1]
 
                                 if (
                                     ix < 0
@@ -56,18 +56,18 @@ struct MAXPOOL2D:
                                 ):
                                     continue
 
-                                let idx = (
+                                var idx = (
                                     batch * inputs.strides[0]
                                     + in_ch * inputs.strides[1]
                                     + ix * inputs.strides[2]
                                     + iy
                                 )
 
-                                let val = inputs.tensor[idx]
+                                var val = inputs.tensor[idx]
                                 if val > max_val:
                                     max_val = val
 
-                        let out_idx = (
+                        var out_idx = (
                             batch * outputs_strides[0]
                             + in_ch * outputs_strides[1]
                             + x * outputs_strides[2]
@@ -92,11 +92,11 @@ struct MAXPOOL2D:
 
         Upper gradient of shape: [batch_size, out_channels, uX, uY]
         """
-        let inputs = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor
-        let inputs_strides = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].strides
+        var inputs = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].tensor
+        var inputs_strides = GRAPH.graph[GRAPH.get_node_idx(tensor_vec[0])].strides
         var res = Tensor[dtype](inputs.shape())
         
-        let ug_strides = calculate_strides(ug.shape())
+        var ug_strides = calculate_strides(ug.shape())
 
         for batch in range(inputs.dim(0)):
             for in_ch in range(inputs.dim(1)):
@@ -104,12 +104,12 @@ struct MAXPOOL2D:
                     for y in range(ug.dim(3)):
                         var max_val: SIMD[dtype, 1] = neginf[dtype]()
                         var max_idx: Int = -1
-                        let ix_base = x * stride[0] - padding[0]
-                        let iy_base = y * stride[1] - padding[1]
+                        var ix_base = x * stride[0] - padding[0]
+                        var iy_base = y * stride[1] - padding[1]
                         for kx in range(kernel_size[0]):
                             for ky in range(kernel_size[1]):
-                                let ix = ix_base + kx * dilation[0]
-                                let iy = iy_base + ky * dilation[1]
+                                var ix = ix_base + kx * dilation[0]
+                                var iy = iy_base + ky * dilation[1]
                                 
                                 if (
                                     ix < 0
@@ -119,19 +119,19 @@ struct MAXPOOL2D:
                                 ):
                                     continue
 
-                                let idx = (
+                                var idx = (
                                     batch * inputs_strides[0]
                                     + in_ch * inputs_strides[1]
                                     + ix * inputs_strides[2]
                                     + iy
                                 )
 
-                                let val = inputs[idx]
+                                var val = inputs[idx]
                                 if val > max_val:
                                     max_val = val
                                     max_idx = idx
 
-                        let ug_idx = (
+                        var ug_idx = (
                             batch * ug_strides[0] 
                             + in_ch * ug_strides[1]
                             + x * ug_strides[2]

--- a/dainemo/nn/activations.mojo
+++ b/dainemo/nn/activations.mojo
@@ -55,10 +55,10 @@ struct Softmax[axis: Int]:
         # softmax: exp(x_i) / sum(exp(x_j))
         # stable softmax: exp(x_i - max(x_j)) / sum(exp(x_j - max(x_j)))
 
-        let max_values = MAX.forward[axis](input)
-        let input_minus_max = SUB.forward(input, max_values)
-        let exp_values = EXP.forward(input_minus_max)
-        let sum_values = SUM.forward[axis](exp_values)
+        var max_values = MAX.forward[axis](input)
+        var input_minus_max = SUB.forward(input, max_values)
+        var exp_values = EXP.forward(input_minus_max)
+        var sum_values = SUM.forward[axis](exp_values)
 
         return DIV.forward(exp_values, sum_values)
 
@@ -76,11 +76,11 @@ struct LogSoftmax[axis: Int]:
         # stable logsoftmax: log(exp(x_i - max(x_j)) / sum(exp(x_j - max(x_j))))
         # stable logsoftmax: x_i - max(x_j) - log(sum(exp(x_j - max(x_j))))
 
-        let max_values = MAX.forward[axis](input)
-        let input_minus_max = SUB.forward(input, max_values)
-        let exp_values = EXP.forward(input_minus_max)
-        let sum_values = SUM.forward[axis](exp_values)
-        let log_values = LOG.forward(sum_values)
+        var max_values = MAX.forward[axis](input)
+        var input_minus_max = SUB.forward(input, max_values)
+        var exp_values = EXP.forward(input_minus_max)
+        var sum_values = SUM.forward[axis](exp_values)
+        var log_values = LOG.forward(sum_values)
 
         return SUB.forward(input_minus_max, log_values)
 

--- a/dainemo/nn/layers/conv.mojo
+++ b/dainemo/nn/layers/conv.mojo
@@ -34,7 +34,7 @@ struct Conv2d[
     fn __init__(
         inout self, in_channels: Int, out_channels: Int, kernel_size: Tuple[Int, Int]
     ):
-        let k: SIMD[dtype, 1] = in_channels * kernel_size.get[0, Int]() * kernel_size.get[1, Int]()
+        var k: SIMD[dtype, 1] = in_channels * kernel_size.get[0, Int]() * kernel_size.get[1, Int]()
         self.weights = Node[dtype](
             rand_uniform[dtype, nelts](
                 TensorShape(out_channels, in_channels, kernel_size.get[0, Int](), kernel_size.get[1, Int]()),
@@ -59,8 +59,8 @@ struct Conv2d[
         # COPY self.weight & self.bias directly from GRAPH
         # Workaround because model parameters are created and change in copies.
         # TODO: Redo when lifetimes are there. [INVESTIGATE HOW TO AVOID THIS]
-        let weights = GRAPH.graph[GRAPH.get_node_idx(self.weights.uuid)]
-        let bias = GRAPH.graph[GRAPH.get_node_idx(self.bias.uuid)]
+        var weights = GRAPH.graph[GRAPH.get_node_idx(self.weights.uuid)]
+        var bias = GRAPH.graph[GRAPH.get_node_idx(self.bias.uuid)]
 
         return CONV2D.forward[padding, stride, dilation](inputs, weights, bias)
 

--- a/dainemo/nn/layers/linear.mojo
+++ b/dainemo/nn/layers/linear.mojo
@@ -19,7 +19,7 @@ struct Linear(Layer):
     var bias: Node[dtype]
 
     fn __init__(inout self, n_input: Int, n_output: Int):
-        let k: SIMD[dtype, 1] =  1.0 / n_input
+        var k: SIMD[dtype, 1] =  1.0 / n_input
         self.weights = Node[dtype](
             rand_uniform[dtype, nelts](TensorShape(n_input, n_output), -sqrt(k), sqrt(k)),
             requires_grad=True,
@@ -40,10 +40,10 @@ struct Linear(Layer):
         # COPY self.weight & self.bias directly from GRAPH
         # Workaround because model parameters are created and change in copies. 
         # TODO: Redo when lifetimes are there. [INVESTIGATE HOW TO AVOID THIS]
-        let weights = GRAPH.graph[GRAPH.get_node_idx(self.weights.uuid)]
-        let bias = GRAPH.graph[GRAPH.get_node_idx(self.bias.uuid)]
+        var weights = GRAPH.graph[GRAPH.get_node_idx(self.weights.uuid)]
+        var bias = GRAPH.graph[GRAPH.get_node_idx(self.bias.uuid)]
 
-        let res = DOT.forward(inputs, weights)
+        var res = DOT.forward(inputs, weights)
         return ADD.forward(res, bias)
 
     fn __call__(self, inputs: Node[dtype]) -> Node[dtype]:

--- a/dainemo/nn/loss.mojo
+++ b/dainemo/nn/loss.mojo
@@ -18,10 +18,10 @@ struct MSELoss:
         """
         # 1/2N * sum( (outputs - targets)^2 )
 
-        let difference = SUB.forward(outputs, Node[dtype](targets))
-        let squared_difference = POW.forward(difference, 2)
-        let res = SUM.forward(squared_difference)
-        let div2N: SIMD[dtype, 1] = (1/(2*outputs.tensor.num_elements())).cast[dtype]()
+        var difference = SUB.forward(outputs, Node[dtype](targets))
+        var squared_difference = POW.forward(difference, 2)
+        var res = SUM.forward(squared_difference)
+        var div2N: SIMD[dtype, 1] = (1/(2*outputs.tensor.num_elements())).cast[dtype]()
         return MUL.forward(res, div2N)
 
     fn __call__(inout self, outputs: Node[dtype], targets: Tensor[dtype]) -> Node[dtype]:
@@ -41,13 +41,13 @@ struct CrossEntropyLoss:
         # -1/N * sum( targets * log_softmax(outputs) )
         
         # LogSoftmax
-        let act = nn.activations.LogSoftmax[axis=1]()
-        let log_softmax = act(outputs)
+        var act = nn.activations.LogSoftmax[axis=1]()
+        var log_softmax = act(outputs)
         
         # CrossEntropy (reduction Mean)
-        let targets_log_softmax = MUL.forward(Node[dtype](targets), log_softmax)
-        let ret = SUM.forward(targets_log_softmax)
-        let negDivN: SIMD[dtype, 1] = (-1/outputs.tensor.dim(0)).cast[dtype]()
+        var targets_log_softmax = MUL.forward(Node[dtype](targets), log_softmax)
+        var ret = SUM.forward(targets_log_softmax)
+        var negDivN: SIMD[dtype, 1] = (-1/outputs.tensor.dim(0)).cast[dtype]()
         return MUL.forward(ret, negDivN)
 
     fn __call__(inout self, inout outputs: Node[dtype], targets: Tensor[dtype]) -> Node[dtype]:

--- a/dainemo/nn/optim.mojo
+++ b/dainemo/nn/optim.mojo
@@ -52,9 +52,9 @@ struct Adam:
                 )
                 
                 # 2. Compute bias-corrected adam grads
-                let bias_corrected_momentum_grad = elwise_op[dtype, nelts, div](param.optim_momentum_grad, 1 - (self.beta1 ** self.iter))
-                let bias_corrected_rms_grad = elwise_op[dtype, nelts, div](param.optim_rms_grad, 1 - (self.beta2 ** self.iter))
-                let delta = elwise_op[dtype, nelts, div](
+                var bias_corrected_momentum_grad = elwise_op[dtype, nelts, div](param.optim_momentum_grad, 1 - (self.beta1 ** self.iter))
+                var bias_corrected_rms_grad = elwise_op[dtype, nelts, div](param.optim_rms_grad, 1 - (self.beta2 ** self.iter))
+                var delta = elwise_op[dtype, nelts, div](
                     bias_corrected_momentum_grad, 
                     elwise_op[dtype, nelts, add](elwise_transform[dtype, nelts, sqrt](bias_corrected_rms_grad), self.epsilon)
                 )

--- a/dainemo/utils/dataloader.mojo
+++ b/dainemo/utils/dataloader.mojo
@@ -57,7 +57,7 @@ struct DataLoader[dtype: DType]:
             self._label_shape.push_back(self.labels.dim(i))
 
         # Handle data as a (total x flattened data element) tensor
-        let total = data.shape()[0]
+        var total = data.shape()[0]
         try:
             assert_equal(labels.shape()[0], total)
             self.data.ireshape(TensorShape(total, data.num_elements() // total))
@@ -74,20 +74,20 @@ struct DataLoader[dtype: DType]:
 
     fn __iter__(inout self) -> DataLoader[dtype]:
         self._current_index = 0
-        let full_batches = self.data.dim(0) // self.batch_size
-        let remainder = 1 if self.data.dim(0) % self.batch_size != 0 else 0
+        var full_batches = self.data.dim(0) // self.batch_size
+        var remainder = 1 if self.data.dim(0) % self.batch_size != 0 else 0
         self._num_batches = full_batches + remainder
         return self
 
     fn __next__(inout self) -> MyBatch[dtype]:
-        let start = self._current_index
-        let end = min(self._current_index + self.batch_size, self.data.dim(0))
+        var start = self._current_index
+        var end = min(self._current_index + self.batch_size, self.data.dim(0))
         
         self._data_shape[0] = end - start
         self._label_shape[0] = end - start
 
-        let data_batch = self.create_batch(self.data, TensorShape(self._data_shape), start)
-        let label_batch = self.create_batch(self.labels, TensorShape(self._label_shape), start) 
+        var data_batch = self.create_batch(self.data, TensorShape(self._data_shape), start)
+        var label_batch = self.create_batch(self.labels, TensorShape(self._label_shape), start) 
         
         self._current_index += self.batch_size
         self._num_batches -= 1
@@ -110,7 +110,7 @@ struct DataLoader[dtype: DType]:
                     tensor.simd_load[nelts](Index(start + n, i))
                 )
 
-            vectorize[nelts, calc_batch](shape.num_elements() // shape[0])
+            vectorize[calc_batch, nelts](shape.num_elements() // shape[0])
 
         parallelize[calc_row](shape[0], shape[0])
 

--- a/dainemo/utils/datasets.mojo
+++ b/dainemo/utils/datasets.mojo
@@ -13,12 +13,12 @@ struct BostonHousing[dtype: DType]:
         var s = read_file(file_path)
         s = s[find_first(s, "\n")+1:]       # Ignore header
 
-        let N = num_lines(s)       
+        var N = num_lines(s)
         self.data = Tensor[dtype](N, 13)        # All columns except the last one
         self.labels = Tensor[dtype](N, 1)       # Only the last column (MEDV), Always specify 1!
 
-        let idx_low: Int
-        let idx_high: Int
+        var idx_low: Int
+        var idx_high: Int
         var idx_line: Int = 0
 
         # Load data in Tensor   
@@ -55,12 +55,12 @@ struct MNIST[dtype: DType]:
         var s = read_file(file_path)
         s = s[find_first(s, "\n")+1:]   # Ignore header
 
-        let N = num_lines(s)                   
+        var N = num_lines(s)
         self.data = Tensor[dtype](N, 1, 28, 28)
         self.labels = Tensor[dtype](N, 1)       # Always specify 1!
 
-        let idx_low: Int
-        let idx_high: Int
+        var idx_low: Int
+        var idx_high: Int
         var idx_line: Int = 0
 
         # Load data in Tensor   
@@ -84,7 +84,7 @@ struct MNIST[dtype: DType]:
 
 
 fn read_file(file_path: String) raises -> String:
-    let s: String
+    var s: String
     with open(file_path, "r") as f:
         s = f.read()
     return s
@@ -122,7 +122,7 @@ fn cast_string[dtype: DType](s: String) raises -> SIMD[dtype, 1]:
     Cast a string with decimal to a SIMD vector of dtype.
     '''
     
-    let idx = find_first(s, delimiter=".")
+    var idx = find_first(s, delimiter=".")
     var x: SIMD[dtype, 1] = -1
 
     if idx == -1:
@@ -130,8 +130,8 @@ fn cast_string[dtype: DType](s: String) raises -> SIMD[dtype, 1]:
         x = atol(s)
         return x
     else:
-        let c_int: SIMD[dtype, 1]
-        let c_frac: SIMD[dtype, 1]
+        var c_int: SIMD[dtype, 1]
+        var c_frac: SIMD[dtype, 1]
         c_int = atol(s[:idx])
         c_frac = atol(s[idx+1:])
         x = c_int + c_frac / (10 ** len(s[idx+1:]))

--- a/dainemo/utils/uuid.mojo
+++ b/dainemo/utils/uuid.mojo
@@ -40,8 +40,8 @@ fn uuid() -> String:
     # (Mojo v0.5.0) Can only find the ability of generating random_ui64
     # Adapt the range to 0..2^8-1 to fit the type of UInt8
     for i in range(16):
-        let ui64_value: UInt64 = random.random_ui64(0, 255)
-        let ui8_value: UInt8 = ui64_value.cast[DType.uint8]()
+        var ui64_value: UInt64 = random.random_ui64(0, 255)
+        var ui8_value: UInt8 = ui64_value.cast[DType.uint8]()
 
         uuid[i] = ui8_value
     

--- a/examples/housing.mojo
+++ b/examples/housing.mojo
@@ -21,7 +21,7 @@ struct LinearRegression:
 
 
 fn main():
-    let train_data: BostonHousing[dtype]
+    var train_data: BostonHousing[dtype]
     try:
         train_data = BostonHousing[dtype](file_path='./examples/data/housing.csv')
     except:
@@ -51,7 +51,7 @@ fn main():
         for batch in training_loader:
 
             # Forward pass
-            let output = model.forward(batch.data)          
+            var output = model.forward(batch.data)
             var loss = loss_func(output, batch.labels)
 
             # Backward pass

--- a/examples/mnist.mojo
+++ b/examples/mnist.mojo
@@ -17,7 +17,7 @@ def plot_image[dtype: DType](borrowed data: Tensor[dtype], num: Int):
     np = Python.import_module("numpy")
     plt = Python.import_module("matplotlib.pyplot")
 
-    let pyimage: PythonObject = np.empty((28, 28), np.float64)
+    var pyimage: PythonObject = np.empty((28, 28), np.float64)
     for m in range(28):
         for n in range(28):
             pyimage.itemset((m, n), data[Index(num, 0, m, n)])
@@ -71,7 +71,7 @@ fn main():
     alias learning_rate = 1e-3
     
     
-    let train_data: MNIST[dtype]
+    var train_data: MNIST[dtype]
     try:
         train_data = MNIST[dtype](file_path='./examples/data/mnist_test_small.csv')
         # _ = plot_image[dtype](train_data.data, 1)
@@ -89,8 +89,8 @@ fn main():
     var loss_func = nn.CrossEntropyLoss()
     var optim = nn.optim.Adam(lr=learning_rate)
 
-    let batch_data: Tensor[dtype]
-    let batch_labels: Tensor[dtype]
+    var batch_data: Tensor[dtype]
+    var batch_labels: Tensor[dtype]
     for epoch in range(num_epochs):
         var num_batches: Int = 0
         var epoch_loss: Float32 = 0.0

--- a/test/test_activations.mojo
+++ b/test/test_activations.mojo
@@ -15,7 +15,7 @@ fn test_SOFTMAX() raises:
     var x = Tensor[dtype](2, 3, 2)
     fill[dtype, nelts](x, 4)
 
-    let f0 = nn.Softmax[0]()
+    var f0 = nn.Softmax[0]()
     var res = f0(x)
     var expected = Tensor[dtype](2, 3, 2)
     fill[dtype, nelts](expected, 0.5)
@@ -23,7 +23,7 @@ fn test_SOFTMAX() raises:
     assert_equal(GRAPH.graph.size, 6) # inputs, max_values, exp_values, sum_values, diff_max_values, result_div
     GRAPH.reset_all()
 
-    let f1 = nn.Softmax[1]()
+    var f1 = nn.Softmax[1]()
     res = f1(x)
     expected = Tensor[dtype](2, 3, 2)
     fill[dtype, nelts](expected, 1.0 / 3.0)
@@ -31,7 +31,7 @@ fn test_SOFTMAX() raises:
     assert_equal(GRAPH.graph.size, 6)
     GRAPH.reset_all()
 
-    let f2 = nn.Softmax[2]()
+    var f2 = nn.Softmax[2]()
     res = f2(x)
     expected = Tensor[dtype](2, 3, 2)
     fill[dtype, nelts](expected, 0.5)
@@ -45,7 +45,7 @@ fn test_LOGSOFTMAX() raises:
     var x = Tensor[dtype](2, 3, 2)
     fill[dtype, nelts](x, 4)
 
-    let f0 = nn.LogSoftmax[0]()
+    var f0 = nn.LogSoftmax[0]()
     var res = f0(x)
     var expected = Tensor[dtype](2, 3, 2)
     fill[dtype, nelts](expected, -0.69314718)
@@ -53,7 +53,7 @@ fn test_LOGSOFTMAX() raises:
     assert_equal(GRAPH.graph.size, 7) # inputs, max_values, exp_values, sum_values, diff_max_values, log_values, result_sub
     GRAPH.reset_all()
 
-    let f1 = nn.LogSoftmax[1]()
+    var f1 = nn.LogSoftmax[1]()
     res = f1(x)
     expected = Tensor[dtype](2, 3, 2)
     fill[dtype, nelts](expected, -1.09861231)
@@ -61,7 +61,7 @@ fn test_LOGSOFTMAX() raises:
     assert_equal(GRAPH.graph.size, 7)
     GRAPH.reset_all()
 
-    let f2 = nn.LogSoftmax[2]()
+    var f2 = nn.LogSoftmax[2]()
     res = f2(x)
     expected = Tensor[dtype](2, 3, 2)
     fill[dtype, nelts](expected, -0.69314718)
@@ -78,8 +78,8 @@ fn test_RELU() raises:
     for i in range(3, 6):
         t1[i] = -3
 
-    let f = nn.ReLU()
-    let res = f(t1)
+    var f = nn.ReLU()
+    var res = f(t1)
 
     var expected = Tensor[dtype](2, 3)
     for i in range(3):
@@ -93,18 +93,18 @@ fn test_RELU() raises:
 
 # <------------SIGMOID------------>
 fn test_SIGMOID() raises:
-    let t1: Tensor[dtype] = Tensor[dtype](2, 3)  # filled with zeroes
+    var t1: Tensor[dtype] = Tensor[dtype](2, 3)  # filled with zeroes
 
     var upper_grad: Tensor[dtype] = Tensor[dtype](2, 3)
     fill[dtype, nelts](upper_grad, 5.0)
 
-    let f = nn.Sigmoid()
-    let res = f(t1)
+    var f = nn.Sigmoid()
+    var res = f(t1)
 
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 1)
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
 
     var expected_ug1 = Tensor[dtype](2, 3)
     fill[dtype, nelts](
@@ -116,10 +116,10 @@ fn test_SIGMOID() raises:
 
 # <------------TANH------------>
 fn test_TANH() raises:
-    let t1: Tensor[dtype] = Tensor[dtype](2, 3)
+    var t1: Tensor[dtype] = Tensor[dtype](2, 3)
 
-    let f = nn.Tanh()
-    let res = f(t1)
+    var f = nn.Tanh()
+    var res = f(t1)
 
     var expected = Tensor[dtype](2, 3)
     fill[dtype, nelts](expected, 0.0)

--- a/test/test_backward.mojo
+++ b/test/test_backward.mojo
@@ -22,13 +22,13 @@ fn test_ADD() raises:
     fill[dtype, nelts](t2, 2.0)
     fill[dtype, nelts](upper_grad, 1.0)
 
-    let res = ADD.forward(t1, t2)
+    var res = ADD.forward(t1, t2)
 
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 2)
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
-    let ug2 = gn.backward_fn(upper_grad, gn.parents, 1)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug2 = gn.backward_fn(upper_grad, gn.parents, 1)
 
     assert_tensors_equal(ug1, upper_grad)
     assert_tensors_equal(ug1, upper_grad)
@@ -44,13 +44,13 @@ fn test_SUB() raises:
     fill[dtype, nelts](t2, 2.0)
     fill[dtype, nelts](upper_grad, 1.0)
 
-    let res = SUB.forward(t1, t2)
+    var res = SUB.forward(t1, t2)
 
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 2)
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
-    let ug2 = gn.backward_fn(upper_grad, gn.parents, 1)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug2 = gn.backward_fn(upper_grad, gn.parents, 1)
 
     var expected_ug2 = Tensor[dtype](2, 3)
     fill[dtype, nelts](expected_ug2, -1.0)
@@ -69,13 +69,13 @@ fn test_MUL() raises:
     fill[dtype, nelts](t2, 2.0)
     fill[dtype, nelts](upper_grad, 1.0)
 
-    let res = MUL.forward(t1, t2)
+    var res = MUL.forward(t1, t2)
 
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 2)
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
-    let ug2 = gn.backward_fn(upper_grad, gn.parents, 1)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug2 = gn.backward_fn(upper_grad, gn.parents, 1)
 
     var expected_ug1 = Tensor[dtype](2, 3)
     fill[dtype, nelts](expected_ug1, 2.0)
@@ -96,13 +96,13 @@ fn test_DIV() raises:
     fill[dtype, nelts](t2, 2.0)
     fill[dtype, nelts](upper_grad, 1.0)
 
-    let res = DIV.forward(t1, t2)
+    var res = DIV.forward(t1, t2)
 
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 2)
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
-    let ug2 = gn.backward_fn(upper_grad, gn.parents, 1)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug2 = gn.backward_fn(upper_grad, gn.parents, 1)
 
     var expected_ug1 = Tensor[dtype](2, 3)
     fill[dtype, nelts](expected_ug1, 1.0 / 2.0)
@@ -123,13 +123,13 @@ fn test_DOT() raises:
     fill[dtype, nelts](t2, 2.0)
     fill[dtype, nelts](upper_grad, 1.0)
 
-    let res = DOT.forward(t1, t2)
+    var res = DOT.forward(t1, t2)
 
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 2)
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
-    let ug2 = gn.backward_fn(upper_grad, gn.parents, 1)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug2 = gn.backward_fn(upper_grad, gn.parents, 1)
 
     var expected_ug1 = Tensor[dtype](2, 2)
     fill[dtype, nelts](expected_ug1, 6.0)
@@ -148,12 +148,12 @@ fn test_EXP() raises:
     fill[dtype, nelts](t1, 2.0)
     fill[dtype, nelts](upper_grad, 5.0)
 
-    let res = EXP.forward(t1)
+    var res = EXP.forward(t1)
 
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 1)
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
 
     var expected_ug1 = Tensor[dtype](2, 3)
     fill[dtype, nelts](expected_ug1, 5.0 * exp[dtype, 1](2.0))
@@ -168,12 +168,12 @@ fn test_LOG() raises:
     fill[dtype, nelts](t1, 2.0)
     fill[dtype, nelts](upper_grad, 5.0)
 
-    let res = LOG.forward(t1)
+    var res = LOG.forward(t1)
 
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 1)
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
 
     var expected_ug1 = Tensor[dtype](2, 3)
     fill[dtype, nelts](expected_ug1, 5.0 / 2.0)
@@ -188,13 +188,13 @@ fn test_POW() raises:
     fill[dtype, nelts](t2, 2.0)
     fill[dtype, nelts](upper_grad, 1.0)
 
-    let res = POW.forward(t2, 2)
+    var res = POW.forward(t2, 2)
 
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 2)
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
-    let ug2 = gn.backward_fn(upper_grad, gn.parents, 1)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug2 = gn.backward_fn(upper_grad, gn.parents, 1)
 
     var expected_ug1 = Tensor[dtype](2, 3)
     fill[dtype, nelts](expected_ug1, 4.0)
@@ -212,15 +212,15 @@ fn test_SUM() raises:
     var t1: Tensor[dtype] = Tensor[dtype](2, 3)
     fill[dtype, nelts](t1, 1.0)
 
-    let res = SUM.forward(t1)
+    var res = SUM.forward(t1)
 
     # uppergrad has always to same shape as res
     var upper_grad: Tensor[dtype] = Tensor[dtype](res.tensor.shape())
     fill[dtype, nelts](upper_grad, 9.0)
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 1)  # one parent
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
 
     var expected_ug1 = Tensor[dtype](2, 3)
     fill[dtype, nelts](expected_ug1, 9.0)
@@ -233,17 +233,17 @@ fn test_SUM_0() raises:
     var t1: Tensor[dtype] = Tensor[dtype](2, 3)
     fill[dtype, nelts](t1, 1.0)
 
-    let res = SUM.forward[axis=0](t1)
+    var res = SUM.forward[axis=0](t1)
 
     # uppergrad has always to same shape as res
     var upper_grad: Tensor[dtype] = Tensor[dtype](res.tensor.shape())
     upper_grad[0] = 0.0
     upper_grad[1] = 1.0
     upper_grad[2] = 2.0
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 1)  # one parent
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
 
     var expected_ug1 = Tensor[dtype](2, 3)
     for i in range(expected_ug1.num_elements()):
@@ -257,16 +257,16 @@ fn test_SUM_1() raises:
     var t1: Tensor[dtype] = Tensor[dtype](2, 3)
     fill[dtype, nelts](t1, 1.0)
 
-    let res = SUM.forward[axis=1](t1)
+    var res = SUM.forward[axis=1](t1)
 
     # uppergrad has always to same shape as res
     var upper_grad: Tensor[dtype] = Tensor[dtype](res.tensor.shape())
     upper_grad[0] = 0.0
     upper_grad[1] = 1.0
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 1)  # one parent
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
 
     var expected_ug1 = Tensor[dtype](2, 3)
     for i in range(expected_ug1.num_elements()):
@@ -283,15 +283,15 @@ fn test_MAX() raises:
     t1[0] = 2.0
     t1[1] = 2.0
 
-    let res = MAX.forward(t1)
+    var res = MAX.forward(t1)
 
     # uppergrad has always to same shape as res
     var upper_grad: Tensor[dtype] = Tensor[dtype](res.tensor.shape())
     fill[dtype, nelts](upper_grad, 9.0)
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 1)  # one parent
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
 
     var expected_ug1 = Tensor[dtype](2, 3)
     expected_ug1[0] = 4.5
@@ -307,15 +307,15 @@ fn test_MAX_0() raises:
         t1[i] = i + 1
     t1[0] = 7.0
 
-    let res = MAX.forward[axis=0](t1)
+    var res = MAX.forward[axis=0](t1)
 
     # uppergrad has always to same shape as res
     var upper_grad: Tensor[dtype] = Tensor[dtype](res.tensor.shape())
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     fill[dtype, nelts](upper_grad, 2.0)
     assert_equal(gn.parents.size, 1)  # one parent
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
 
     var expected_ug1 = Tensor[dtype](2, 3, 2)
     expected_ug1[0] = 1.0
@@ -336,15 +336,15 @@ fn test_MAX_1() raises:
         t1[i] = i + 1
     t1[0] = 5.0
 
-    let res = MAX.forward[axis=1](t1)
+    var res = MAX.forward[axis=1](t1)
 
     # uppergrad has always to same shape as res
     var upper_grad: Tensor[dtype] = Tensor[dtype](res.tensor.shape())
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     fill[dtype, nelts](upper_grad, 2.0)
     assert_equal(gn.parents.size, 1)  # one parent
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
 
     var expected_ug1 = Tensor[dtype](2, 3, 2)
     expected_ug1[0] = 1.0
@@ -363,15 +363,15 @@ fn test_MAX_2() raises:
         t1[i] = i + 1
     t1[0] = 2.0
 
-    let res = MAX.forward[axis=2](t1)
+    var res = MAX.forward[axis=2](t1)
 
     # uppergrad has always to same shape as res
     var upper_grad: Tensor[dtype] = Tensor[dtype](res.tensor.shape())
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     fill[dtype, nelts](upper_grad, 2.0)
     assert_equal(gn.parents.size, 1)  # one parent
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
 
     var expected_ug1 = Tensor[dtype](2, 3, 2)
     expected_ug1[0] = 1.0
@@ -387,9 +387,9 @@ fn test_MAX_2() raises:
 
 # <------------TRANSPOSE------------>
 fn test_TRANSPOSE() raises:
-    let t1 = Tensor[dtype](2, 3)
+    var t1 = Tensor[dtype](2, 3)
 
-    let res = TRANSPOSE.forward(t1)
+    var res = TRANSPOSE.forward(t1)
 
     # uppergrad has always to same shape as res
     var upper_grad: Tensor[dtype] = Tensor[dtype](res.tensor.shape())
@@ -398,10 +398,10 @@ fn test_TRANSPOSE() raises:
     for i in range(3):
         upper_grad[2*i] = i+1
         upper_grad[2*i+1] = i+4
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 1)  # one parent
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
 
     var expected_ug1 = Tensor[dtype](t1.shape())
     for i in range(6):
@@ -412,18 +412,18 @@ fn test_TRANSPOSE() raises:
 
 # <------------FLATTEN------------>
 fn test_FLATTEN() raises:
-    let t1 = Tensor[dtype](2, 3)
+    var t1 = Tensor[dtype](2, 3)
 
-    let res = FLATTEN.forward(t1)
+    var res = FLATTEN.forward(t1)
 
     # uppergrad has always to same shape as res
     var upper_grad: Tensor[dtype] = Tensor[dtype](res.tensor.shape())
     fill[dtype, nelts](upper_grad, 1.0)
     assert_equal(upper_grad.dim(0), 6)
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 1)  # one parent
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
 
     var expected_ug1 = Tensor[dtype](t1.shape())
     fill[dtype, nelts](expected_ug1, 1.0)
@@ -433,20 +433,20 @@ fn test_FLATTEN() raises:
 
 # <------------RESHAPE------------>
 fn test_RESHAPE() raises:
-    let t1 = Tensor[dtype](2, 2, 5)
-    let new_shape = TensorShape(2, 10)
+    var t1 = Tensor[dtype](2, 2, 5)
+    var new_shape = TensorShape(2, 10)
 
-    let res = RESHAPE.forward(t1, new_shape)
+    var res = RESHAPE.forward(t1, new_shape)
 
     # uppergrad has always to same shape as res
     var upper_grad: Tensor[dtype] = Tensor[dtype](res.tensor.shape())
     fill[dtype, nelts](upper_grad, 1.0)
     assert_equal(upper_grad.dim(0), 2)
     assert_equal(upper_grad.dim(1), 10)
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 1)  # one parent
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
 
     var expected_ug1 = Tensor[dtype](t1.shape())
     fill[dtype, nelts](expected_ug1, 1.0)

--- a/test/test_broadcasting.mojo
+++ b/test/test_broadcasting.mojo
@@ -13,7 +13,7 @@ fn to_tensor_shape(owned shape: PythonObject) raises -> TensorShape:
 
 
 fn np_broadcast_shapes(s1: TensorShape, s2: TensorShape) raises -> TensorShape:
-    let np = Python.import_module("numpy")
+    var np = Python.import_module("numpy")
     # Convert to python list
     var s1_py: PythonObject = []
     var s2_py: PythonObject = []
@@ -23,7 +23,7 @@ fn np_broadcast_shapes(s1: TensorShape, s2: TensorShape) raises -> TensorShape:
         s2_py += [s2[i]]
 
     # Numpy broadcast_shapes
-    let py_shape = np.broadcast_shapes(s1_py, s2_py)
+    var py_shape = np.broadcast_shapes(s1_py, s2_py)
 
     return to_tensor_shape(py_shape)
 
@@ -85,7 +85,7 @@ fn test_broadcast_shapes() raises:
 
 
 fn test_broadcast_shapes_multiple() raises:
-    let np = Python.import_module("numpy")
+    var np = Python.import_module("numpy")
 
     var s1 = TensorShape(1, 2)
     var s2 = TensorShape(3, 1)
@@ -97,7 +97,7 @@ fn test_broadcast_shapes_multiple() raises:
     s1 = TensorShape(6, 7)
     s2 = TensorShape(5, 6, 1)
     s3 = TensorShape(7)
-    let s4 = TensorShape(5, 1, 7)
+    var s4 = TensorShape(5, 1, 7)
     res = broadcast_shapes(s1, s2, s3, s4)
     res_np = to_tensor_shape(np.broadcast_shapes((6, 7), (5, 6, 1), (7), (5, 1, 7)))
     assert_true(res == res_np)

--- a/test/test_conv.mojo
+++ b/test/test_conv.mojo
@@ -62,7 +62,7 @@ fn test_get_result_shape() raises:
 
 
 def to_numpy(tensor: Tensor) -> PythonObject:
-    let np = Python.import_module("numpy")
+    var np = Python.import_module("numpy")
     np.set_printoptions(4)
 
     rank = tensor.rank()
@@ -114,18 +114,18 @@ fn torch_conv2d(
     dilation: StaticIntTuple[2],
     upper_grad: Tensor,
 ) -> torch_conv2d_output:
-    let out: torch_conv2d_output
+    var out: torch_conv2d_output
 
     try:
-        let torch = Python.import_module("torch")
-        let F = Python.import_module("torch.nn.functional")
-        let np = Python.import_module("numpy")
+        var torch = Python.import_module("torch")
+        var F = Python.import_module("torch.nn.functional")
+        var np = Python.import_module("numpy")
 
-        let inputs = torch.from_numpy(to_numpy(inputs)).requires_grad_(True)
-        let weights = torch.from_numpy(to_numpy(kernel)).requires_grad_(True)
-        let bias = torch.from_numpy(to_numpy(bias)).requires_grad_(True)
+        var inputs = torch.from_numpy(to_numpy(inputs)).requires_grad_(True)
+        var weights = torch.from_numpy(to_numpy(kernel)).requires_grad_(True)
+        var bias = torch.from_numpy(to_numpy(bias)).requires_grad_(True)
 
-        let expected = F.conv2d(
+        var expected = F.conv2d(
             inputs,
             weights,
             bias,
@@ -135,7 +135,7 @@ fn torch_conv2d(
         )
 
         # uppergrad & backwards
-        let upper_grad = torch.from_numpy(to_numpy(upper_grad))
+        var upper_grad = torch.from_numpy(to_numpy(upper_grad))
         _ = expected.backward(upper_grad)
 
         # expected output
@@ -149,8 +149,8 @@ fn torch_conv2d(
 
     except:
         print("Error importing torch")
-        let d = Tensor[dtype](1)
-        let out: torch_conv2d_output = torch_conv2d_output(d, d, d, d)
+        var d = Tensor[dtype](1)
+        var out: torch_conv2d_output = torch_conv2d_output(d, d, d, d)
         return out
 
 
@@ -165,10 +165,10 @@ fn test_forward_1() raises:
     var kernel = Tensor[dtype](1, 1, 1, 16)
     fill[dtype, nelts](inputs, 1.0)
     fill[dtype, nelts](kernel, 1.0)
-    let bias = Tensor[dtype](1)
+    var bias = Tensor[dtype](1)
 
-    let res = CONV2D.forward[padding, stride, dilation](inputs, kernel, bias)
-    let torch_out = torch_conv2d(
+    var res = CONV2D.forward[padding, stride, dilation](inputs, kernel, bias)
+    var torch_out = torch_conv2d(
         inputs,
         kernel,
         bias=bias,
@@ -195,8 +195,8 @@ fn test_forward_2() raises:
     var bias = Tensor[dtype](1)
     fill[dtype, nelts](bias, 66.99)
 
-    let res = CONV2D.forward[padding, stride, dilation](inputs, kernel, bias)
-    let torch_out = torch_conv2d(
+    var res = CONV2D.forward[padding, stride, dilation](inputs, kernel, bias)
+    var torch_out = torch_conv2d(
         inputs,
         kernel,
         bias=bias,
@@ -223,8 +223,8 @@ fn test_forward_3() raises:
     var bias = Tensor[dtype](2)
     fill[dtype, nelts](bias, 3)
 
-    let res = CONV2D.forward[padding, stride, dilation](inputs, kernel, bias)
-    let torch_out = torch_conv2d(
+    var res = CONV2D.forward[padding, stride, dilation](inputs, kernel, bias)
+    var torch_out = torch_conv2d(
         inputs,
         kernel,
         bias=bias,
@@ -249,19 +249,19 @@ fn test_backward_1() raises:
     var kernel = Tensor[dtype](out_channels, in_channels, 1, 16)
     fill[dtype, nelts](inputs, 1.0)
     fill[dtype, nelts](kernel, 1.0)
-    let bias: Tensor[dtype] = rand[dtype](out_channels)
+    var bias: Tensor[dtype] = rand[dtype](out_channels)
 
-    let res = CONV2D.forward[padding, stride, dilation](inputs, kernel, bias)
+    var res = CONV2D.forward[padding, stride, dilation](inputs, kernel, bias)
 
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 3)
-    let upper_grad: Tensor[dtype] = rand[dtype](res.tensor.shape())
+    var upper_grad: Tensor[dtype] = rand[dtype](res.tensor.shape())
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)  # inputs.grad
-    let ug2 = gn.backward_fn(upper_grad, gn.parents, 1)  # kernel.grad
-    let ug3 = gn.backward_fn(upper_grad, gn.parents, 2)  # bias.grad
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)  # inputs.grad
+    var ug2 = gn.backward_fn(upper_grad, gn.parents, 1)  # kernel.grad
+    var ug3 = gn.backward_fn(upper_grad, gn.parents, 2)  # bias.grad
 
-    let torch_out = torch_conv2d(
+    var torch_out = torch_conv2d(
         inputs,
         kernel,
         bias=bias,
@@ -289,19 +289,19 @@ fn test_backward_2() raises:
     var kernel = Tensor[dtype](out_channels, in_channels, 4, 8)
     fill[dtype, nelts](inputs, 3.0)
     fill[dtype, nelts](kernel, 1.0)
-    let bias: Tensor[dtype] = rand[dtype](out_channels)
+    var bias: Tensor[dtype] = rand[dtype](out_channels)
 
-    let res = CONV2D.forward[padding, stride, dilation](inputs, kernel, bias)
+    var res = CONV2D.forward[padding, stride, dilation](inputs, kernel, bias)
 
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 3)
-    let upper_grad: Tensor[dtype] = rand[dtype](res.tensor.shape())
+    var upper_grad: Tensor[dtype] = rand[dtype](res.tensor.shape())
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)  # inputs.grad
-    let ug2 = gn.backward_fn(upper_grad, gn.parents, 1)  # kernel.grad
-    let ug3 = gn.backward_fn(upper_grad, gn.parents, 2)  # bias.grad
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)  # inputs.grad
+    var ug2 = gn.backward_fn(upper_grad, gn.parents, 1)  # kernel.grad
+    var ug3 = gn.backward_fn(upper_grad, gn.parents, 2)  # bias.grad
 
-    let torch_out = torch_conv2d(
+    var torch_out = torch_conv2d(
         inputs,
         kernel,
         bias=bias,
@@ -329,19 +329,19 @@ fn test_backward_3() raises:
     var kernel = Tensor[dtype](out_channels, in_channels, 5, 6)
     fill[dtype, nelts](inputs, 3.0)
     fill[dtype, nelts](kernel, 4.0)
-    let bias: Tensor[dtype] = rand[dtype](out_channels)
+    var bias: Tensor[dtype] = rand[dtype](out_channels)
 
-    let res = CONV2D.forward[padding, stride, dilation](inputs, kernel, bias)
+    var res = CONV2D.forward[padding, stride, dilation](inputs, kernel, bias)
 
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 3)
-    let upper_grad: Tensor[dtype] = rand[dtype](res.tensor.shape())
+    var upper_grad: Tensor[dtype] = rand[dtype](res.tensor.shape())
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)  # inputs.grad
-    let ug2 = gn.backward_fn(upper_grad, gn.parents, 1)  # kernel.grad
-    let ug3 = gn.backward_fn(upper_grad, gn.parents, 2)  # bias.grad
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)  # inputs.grad
+    var ug2 = gn.backward_fn(upper_grad, gn.parents, 1)  # kernel.grad
+    var ug3 = gn.backward_fn(upper_grad, gn.parents, 2)  # bias.grad
 
-    let torch_out = torch_conv2d(
+    var torch_out = torch_conv2d(
         inputs,
         kernel,
         bias=bias,

--- a/test/test_graph.mojo
+++ b/test/test_graph.mojo
@@ -17,9 +17,9 @@ fn build_test_graph():
     #       node_1   \
     #                  [-] --> node_3
     #       node_2   / 
-    let node_1 = Node(rand[dtype](1, 10))
-    let node_2 = Node(rand[dtype](1, 10))
-    let tensor_3 = rand[dtype](1, 10)
+    var node_1 = Node(rand[dtype](1, 10))
+    var node_2 = Node(rand[dtype](1, 10))
+    var tensor_3 = rand[dtype](1, 10)
 
     # Define node relationships using operation [-] with:
     #      result: tensor_3
@@ -29,9 +29,9 @@ fn build_test_graph():
 
 
 fn test_graph_relations() raises:
-    let n1 = GRAPH.graph[0]
-    let n2 = GRAPH.graph[1]
-    let n3 = GRAPH.graph[2]
+    var n1 = GRAPH.graph[0]
+    var n2 = GRAPH.graph[1]
+    var n3 = GRAPH.graph[2]
 
     assert_equal(GRAPH.graph.size, 3)
     assert_equal(n1.children.size, 1)
@@ -49,7 +49,7 @@ fn test_graph_relations() raises:
 
 fn all_grads_zero() -> Bool:
     for idx in range(GRAPH.graph.size):
-        let grad = GRAPH.graph[idx].grad
+        var grad = GRAPH.graph[idx].grad
         for i in range(grad.num_elements()):
             if grad[i] != 0:
                 return False

--- a/test/test_layers.mojo
+++ b/test/test_layers.mojo
@@ -11,11 +11,11 @@ alias dtype = DType.float32
 
 # <------------LINEAR------------>
 fn test_linear() raises:
-    let f = nn.Linear(5, 3)                             # 5 inputs, 3 outputs
+    var f = nn.Linear(5, 3)                             # 5 inputs, 3 outputs
     
-    let inputs: Tensor[dtype] = rand[dtype](2, 5)       # A batch of 2 with 5 inputs
+    var inputs: Tensor[dtype] = rand[dtype](2, 5)       # A batch of 2 with 5 inputs
     
-    let outputs = f(Node[dtype](inputs))                # Should be a batch of 2 with 3 outputs
+    var outputs = f(Node[dtype](inputs))                # Should be a batch of 2 with 3 outputs
 
     print("Input batch of 2 with 5 inputs:", inputs.shape())
     print("Output batch of 2 with 3 outputs:", outputs.tensor.shape())
@@ -31,22 +31,22 @@ fn test_linear() raises:
 # <------------SEQUENTIAL------------>
 from dainemo.nn.layers import Layer
 fn test_sequential() raises:
-    let f = nn.Linear(5, 3)
-    let g = nn.Linear(3, 2)
-    let seq = nn.Sequential(f)
+    var f = nn.Linear(5, 3)
+    var g = nn.Linear(3, 2)
+    var seq = nn.Sequential(f)
 
-    let inputs: Tensor[dtype] = rand[dtype](2, 5)
+    var inputs: Tensor[dtype] = rand[dtype](2, 5)
     
-    let output_f = f(Node[dtype](inputs))
-    let output_gf = g(output_f)
-    # let output_seq = seq(Node[dtype](inputs))
+    var output_f = f(Node[dtype](inputs))
+    var output_gf = g(output_f)
+    # var output_seq = seq(Node[dtype](inputs))
 
     # print(output_gf)
     # print(output_seq)
 
 # <------------CONV2D------------>
 fn test_conv2d() raises:   
-    let f = nn.Conv2d[
+    var f = nn.Conv2d[
         padding=2,
         stride=1
     ](
@@ -55,9 +55,9 @@ fn test_conv2d() raises:
         kernel_size=(1, 16)
     )
 
-    let inputs: Tensor[dtype] = rand[dtype](4, 1, 28, 28)
+    var inputs: Tensor[dtype] = rand[dtype](4, 1, 28, 28)
     
-    let outputs = f(Node[dtype](inputs))
+    var outputs = f(Node[dtype](inputs))
 
     print("Input batch of 4 with 1x28x28 inputs:", inputs.shape())
     print("Output batch of 4 with 1x32x17 outputs:", outputs.tensor.shape())
@@ -72,7 +72,7 @@ fn test_conv2d() raises:
 
 
 fn test_conv2d_b() raises:
-    let f = nn.Conv2d[
+    var f = nn.Conv2d[
         padding=0,
         stride=1
     ](
@@ -81,9 +81,9 @@ fn test_conv2d_b() raises:
         kernel_size=2
     )
 
-    let inputs: Tensor[dtype] = rand[dtype](4, 1, 32, 17)
+    var inputs: Tensor[dtype] = rand[dtype](4, 1, 32, 17)
 
-    let outputs = f(Node[dtype](inputs))
+    var outputs = f(Node[dtype](inputs))
 
     print("Input batch of 4 with 1x32x17 inputs:", inputs.shape())
     print("Output batch of 4 with 1x31x16 outputs:", outputs.tensor.shape())
@@ -99,14 +99,14 @@ fn test_conv2d_b() raises:
 
 # <------------MAXPOOL2D------------>
 fn test_maxpool2d() raises:
-    let f = nn.MaxPool2d[
+    var f = nn.MaxPool2d[
         kernel_size=5,
         padding=2
     ]()
 
-    let inputs: Tensor[dtype] = rand[dtype](4, 3, 32, 17)
+    var inputs: Tensor[dtype] = rand[dtype](4, 3, 32, 17)
 
-    let outputs = f(Node[dtype](inputs))
+    var outputs = f(Node[dtype](inputs))
 
     print("Input batch of 4 with 3x32x17 inputs:", inputs.shape())
     print("Output batch of 4 with 3x15x8 outputs:", outputs.tensor.shape())

--- a/test/test_loss.mojo
+++ b/test/test_loss.mojo
@@ -19,9 +19,9 @@ fn test_MSE_perfect() raises:
     var labels = Tensor[dtype](2, 10)       
     fill[dtype, nelts](output, 1)
     fill[dtype, nelts](labels, 1)
-    let outputs = Node[dtype](output)
+    var outputs = Node[dtype](output)
 
-    let loss = loss_func(outputs, labels)
+    var loss = loss_func(outputs, labels)
 
     assert_equal(loss.tensor.dim(0), 1)     # MSE summed over all elements
     assert_equal(loss.tensor[0], 0)         # loss is 0
@@ -36,11 +36,11 @@ fn test_MSE_imperfect() raises:
     var output = Tensor[dtype](1, 10)       # batch of 1, 10 classes
     var labels = Tensor[dtype](1, 10)       
     fill[dtype, nelts](output, 1)
-    let outputs = Node[dtype](output)
+    var outputs = Node[dtype](output)
     for i in range(10):
         labels[i] = i
 
-    let loss = loss_func(outputs, labels)
+    var loss = loss_func(outputs, labels)
     
     var expected_loss: SIMD[dtype, 1] = 0.0
     for i in range(10):

--- a/test/test_mlops.mojo
+++ b/test/test_mlops.mojo
@@ -13,9 +13,9 @@ alias nelts: Int = simdwidthof[dtype]()
 
 # <------------SIGMOID------------>
 fn test_SIGMOID() raises:
-    let t1: Tensor[dtype] = Tensor[dtype](2, 3)  # filled with zeroes
+    var t1: Tensor[dtype] = Tensor[dtype](2, 3)  # filled with zeroes
 
-    let res = SIGMOID.forward(t1)
+    var res = SIGMOID.forward(t1)
 
     var expected = Tensor[dtype](2, 3)
     fill[dtype, nelts](expected, 0.5)
@@ -25,17 +25,17 @@ fn test_SIGMOID() raises:
 
 
 fn test_backward_SIGMOID() raises:
-    let t1: Tensor[dtype] = Tensor[dtype](2, 3)  # filled with zeroes
+    var t1: Tensor[dtype] = Tensor[dtype](2, 3)  # filled with zeroes
 
     var upper_grad: Tensor[dtype] = Tensor[dtype](2, 3)
     fill[dtype, nelts](upper_grad, 5.0)
 
-    let res = SIGMOID.forward(t1)
+    var res = SIGMOID.forward(t1)
 
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 1)
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
 
     var expected_ug1 = Tensor[dtype](2, 3)
     fill[dtype, nelts](
@@ -54,7 +54,7 @@ fn test_RELU() raises:
     for i in range(3, 6):
         t1[i] = -3
 
-    let res = RELU.forward(t1)
+    var res = RELU.forward(t1)
 
     var expected = Tensor[dtype](2, 3)
     for i in range(3):
@@ -75,11 +75,11 @@ fn test_backward_RELU() raises:
     var upper_grad: Tensor[dtype] = Tensor[dtype](2, 3)
     fill[dtype, nelts](upper_grad, 5.0)
 
-    let res = RELU.forward(t1)
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var res = RELU.forward(t1)
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 1)
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
 
     var expected_ug1 = Tensor[dtype](2, 3)
     for i in range(3):
@@ -92,9 +92,9 @@ fn test_backward_RELU() raises:
 
 # <------------TANH------------>
 fn test_TANH() raises:
-    let t1: Tensor[dtype] = Tensor[dtype](2, 3)  # filled with zeroes
+    var t1: Tensor[dtype] = Tensor[dtype](2, 3)  # filled with zeroes
 
-    let res = TANH.forward(t1)
+    var res = TANH.forward(t1)
 
     var expected = Tensor[dtype](2, 3)
     fill[dtype, nelts](expected, 0.0)
@@ -104,17 +104,17 @@ fn test_TANH() raises:
 
 
 fn test_backward_TANH() raises:
-    let t1: Tensor[dtype] = Tensor[dtype](2, 3)  # filled with zeroes
+    var t1: Tensor[dtype] = Tensor[dtype](2, 3)  # filled with zeroes
 
     var upper_grad: Tensor[dtype] = Tensor[dtype](2, 3)
     fill[dtype, nelts](upper_grad, 5.0)
 
-    let res = TANH.forward(t1)
+    var res = TANH.forward(t1)
 
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 1)
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0)
 
     var expected_ug1 = Tensor[dtype](2, 3)
     fill[dtype, nelts](expected_ug1, 5.0 * 1.0)  # 1.0 = d(tanh(0))/dx = 1 - tanh(0)^2

--- a/test/test_models_torch.mojo
+++ b/test/test_models_torch.mojo
@@ -36,10 +36,10 @@ struct Linear(Layer):
         """
         Forward pass of the linear layer.
         """
-        let weights = GRAPH.graph[GRAPH.get_node_idx(self.weights.uuid)]
-        let bias = GRAPH.graph[GRAPH.get_node_idx(self.bias.uuid)]
+        var weights = GRAPH.graph[GRAPH.get_node_idx(self.weights.uuid)]
+        var bias = GRAPH.graph[GRAPH.get_node_idx(self.bias.uuid)]
 
-        let res = DOT.forward(inputs, weights)
+        var res = DOT.forward(inputs, weights)
         return ADD.forward(res, bias)
 
     fn __call__(self, inputs: Node[dtype]) -> Node[dtype]:
@@ -75,8 +75,8 @@ struct Conv2d[
         """
         Forward pass of the convolution layer.
         """
-        let weights = GRAPH.graph[GRAPH.get_node_idx(self.weights.uuid)]
-        let bias = GRAPH.graph[GRAPH.get_node_idx(self.bias.uuid)]
+        var weights = GRAPH.graph[GRAPH.get_node_idx(self.weights.uuid)]
+        var bias = GRAPH.graph[GRAPH.get_node_idx(self.bias.uuid)]
 
         return CONV2D.forward[padding, stride, dilation](inputs, weights, bias)
 
@@ -178,29 +178,29 @@ fn run_torch(
     var out: DynamicVector[Float32] = DynamicVector[Float32]()
 
     try:
-        let torch = Python.import_module("torch")
-        let F = Python.import_module("torch.nn.functional")
-        let np = Python.import_module("numpy")
+        var torch = Python.import_module("torch")
+        var F = Python.import_module("torch.nn.functional")
+        var np = Python.import_module("numpy")
         Python.add_to_path("./test")
-        let cnn_class = Python.import_module("test_cnn_class_torch")
+        var cnn_class = Python.import_module("test_cnn_class_torch")
 
-        let inputs = torch.from_numpy(to_numpy(inputs)).requires_grad_(True)
-        let labels = torch.from_numpy(to_numpy(labels)).requires_grad_(True)
+        var inputs = torch.from_numpy(to_numpy(inputs)).requires_grad_(True)
+        var labels = torch.from_numpy(to_numpy(labels)).requires_grad_(True)
 
-        let conv1_weights = torch.from_numpy(to_numpy(conv1_weights)).requires_grad_(
+        var conv1_weights = torch.from_numpy(to_numpy(conv1_weights)).requires_grad_(
             True
         )
-        let conv1_bias = torch.from_numpy(to_numpy(conv1_bias)).requires_grad_(True)
-        let conv2_weights = torch.from_numpy(to_numpy(conv2_weights)).requires_grad_(
+        var conv1_bias = torch.from_numpy(to_numpy(conv1_bias)).requires_grad_(True)
+        var conv2_weights = torch.from_numpy(to_numpy(conv2_weights)).requires_grad_(
             True
         )
-        let conv2_bias = torch.from_numpy(to_numpy(conv2_bias)).requires_grad_(True)
-        let linear1_weights = torch.from_numpy(
+        var conv2_bias = torch.from_numpy(to_numpy(conv2_bias)).requires_grad_(True)
+        var linear1_weights = torch.from_numpy(
             to_numpy(linear1_weights)
         ).requires_grad_(True)
-        let linear1_bias = torch.from_numpy(to_numpy(linear1_bias)).requires_grad_(True)
+        var linear1_bias = torch.from_numpy(to_numpy(linear1_bias)).requires_grad_(True)
 
-        let cnn = cnn_class.CNN(
+        var cnn = cnn_class.CNN(
             conv1_weights,
             conv1_bias,
             conv2_weights,
@@ -209,13 +209,13 @@ fn run_torch(
             linear1_bias,
         )
 
-        # let loss_func = cnn_class.CrossEntropyLoss2()
-        let loss_func = torch.nn.CrossEntropyLoss()
-        let optimizer = torch.optim.Adam(cnn.parameters(), learning_rate)
+        # var loss_func = cnn_class.CrossEntropyLoss2()
+        var loss_func = torch.nn.CrossEntropyLoss()
+        var optimizer = torch.optim.Adam(cnn.parameters(), learning_rate)
 
         for i in range(epochs):
-            let output = cnn.forward(inputs)
-            let loss = loss_func(output, labels)
+            var output = cnn.forward(inputs)
+            var loss = loss_func(output, labels)
 
             _ = optimizer.zero_grad()
             _ = loss.backward()
@@ -236,31 +236,31 @@ fn he_uniform(shape: TensorShape, fan_in: Int) -> Tensor[dtype]:
     Returns a tensor with random values between -h and h.
     """
     alias nelts = simdwidthof[dtype]()
-    let k: SIMD[dtype, 1] = 1.0 / fan_in
-    let h = sqrt(k)
+    var k: SIMD[dtype, 1] = 1.0 / fan_in
+    var h = sqrt(k)
     return rand_uniform[dtype, nelts](shape, -h, h)
 
 
 fn main():
-    let learning_rate = 1e-3
-    let epochs = 20
-    let batch_size = 4
+    var learning_rate = 1e-3
+    var epochs = 20
+    var batch_size = 4
 
-    let inputs = rand[dtype](batch_size, 1, 28, 28)
+    var inputs = rand[dtype](batch_size, 1, 28, 28)
     var labels = Tensor[dtype](batch_size, 10) # one-hot encoded (probabilities)
     for i in range(4):
         labels[i * 10 + i] = 1.0
 
-    let conv1_weights = he_uniform(TensorShape(16, 1, 5, 5), 1)
-    let conv1_bias = Tensor[dtype](16)
+    var conv1_weights = he_uniform(TensorShape(16, 1, 5, 5), 1)
+    var conv1_bias = Tensor[dtype](16)
 
-    let conv2_weights = he_uniform(TensorShape(32, 16, 5, 5), 2)
-    let conv2_bias = Tensor[dtype](32)
+    var conv2_weights = he_uniform(TensorShape(32, 16, 5, 5), 2)
+    var conv2_bias = Tensor[dtype](32)
 
-    let linear1_weights = he_uniform(TensorShape(32 * 7 * 7, 10), 32 * 7 * 7)
-    let linear1_bias = Tensor[dtype](10)
+    var linear1_weights = he_uniform(TensorShape(32 * 7 * 7, 10), 32 * 7 * 7)
+    var linear1_bias = Tensor[dtype](10)
 
-    let losses_mojo = run_mojo(
+    var losses_mojo = run_mojo(
         epochs,
         learning_rate,
         inputs,
@@ -273,7 +273,7 @@ fn main():
         linear1_bias,
     )
 
-    let losses_torch = run_torch(
+    var losses_torch = run_torch(
         epochs,
         learning_rate,
         inputs,
@@ -290,8 +290,8 @@ fn main():
         print("loss_mojo: ", losses_mojo[i], " loss_torch: ", losses_torch[i])
 
     # for i in range(epochs):
-    #     let loss_mojo = losses_mojo[i]
-    #     let loss_torch = losses_torch[i]
+    #     var loss_mojo = losses_mojo[i]
+    #     var loss_torch = losses_torch[i]
     #     print("loss_mojo: ", loss_mojo, " loss_torch: ", loss_torch)
     #     try:
     #         assert_almost_equal(loss_mojo, loss_torch, 1e-5)

--- a/test/test_node.mojo
+++ b/test/test_node.mojo
@@ -32,9 +32,9 @@ fn build_test_graph():
 
 
 fn test_graph_relations() raises:
-    let n1 = GRAPH.graph[0]
-    let n2 = GRAPH.graph[1]
-    let n3 = GRAPH.graph[2]
+    var n1 = GRAPH.graph[0]
+    var n2 = GRAPH.graph[1]
+    var n3 = GRAPH.graph[2]
 
     assert_equal(GRAPH.graph.size, 3)
     assert_equal(n1.children.size, 1)
@@ -68,7 +68,7 @@ fn test_visited_default() raises:
 
 
 fn test_mark_reset_visited() raises:
-    let idx = 0
+    var idx = 0
 
     assert_equal(GRAPH.graph[idx].visited, False)
     GRAPH.mark_visited(GRAPH.graph[idx].uuid)

--- a/test/test_ops.mojo
+++ b/test/test_ops.mojo
@@ -33,7 +33,7 @@ fn test_ADD() raises:
     fill[dtype, nelts](t1, 1.0)
     fill[dtype, nelts](t2, 1.0)
 
-    let res = ADD.forward(t1, t2)
+    var res = ADD.forward(t1, t2)
 
     var expected = Tensor[dtype](2, 3)
     fill[dtype, nelts](expected, 2.0)
@@ -49,9 +49,9 @@ fn test_SUB() raises:
     fill[dtype, nelts](t1, 1.0)
     fill[dtype, nelts](t2, 1.0)
 
-    let res = SUB.forward(t1, t2)
+    var res = SUB.forward(t1, t2)
 
-    let expected = Tensor[dtype](2, 3)
+    var expected = Tensor[dtype](2, 3)
     assert_tensors_equal(res.tensor, expected)
     assert_equal(GRAPH.graph.size, 3)
     GRAPH.reset_all()
@@ -108,7 +108,7 @@ fn test_DOT() raises:
     fill[dtype, nelts](t1, 1.0)
     fill[dtype, nelts](t2, 1.0)
 
-    let res = DOT.forward(t1, t2)
+    var res = DOT.forward(t1, t2)
 
     var expected = Tensor[dtype](2, 2)
     fill[dtype, nelts](expected, 3.0)
@@ -122,7 +122,7 @@ fn test_EXP() raises:
     var t1: Tensor[dtype] = Tensor[dtype](2, 3)
     fill[dtype, nelts](t1, 2.0)
 
-    let res = EXP.forward(t1)
+    var res = EXP.forward(t1)
 
     var expected = Tensor[dtype](2, 3)
     fill[dtype, nelts](expected, exp[dtype, 1](2.0))
@@ -136,7 +136,7 @@ fn test_LOG() raises:
     var t1: Tensor[dtype] = Tensor[dtype](2, 3)
     fill[dtype, nelts](t1, 2.0)
 
-    let res = LOG.forward(t1)
+    var res = LOG.forward(t1)
 
     var expected = Tensor[dtype](2, 3)
     fill[dtype, nelts](expected, log[dtype, 1](2.0))
@@ -150,7 +150,7 @@ fn test_POW() raises:
     var t1: Tensor[dtype] = Tensor[dtype](2, 3)
     fill[dtype, nelts](t1, 2.0)
 
-    let res = POW.forward(t1, 2)
+    var res = POW.forward(t1, 2)
 
     var expected = Tensor[dtype](2, 3)
     fill[dtype, nelts](expected, 4.0)
@@ -164,7 +164,7 @@ fn test_SUM() raises:
     var t1: Tensor[dtype] = Tensor[dtype](2, 3)
     fill[dtype, nelts](t1, 1.0)
 
-    let res_scalar = SUM.forward(t1)
+    var res_scalar = SUM.forward(t1)
 
     var expected = Tensor[dtype](1)
     fill[dtype, nelts](expected, 6.0)
@@ -172,7 +172,7 @@ fn test_SUM() raises:
     assert_equal(GRAPH.graph.size, 2)
     GRAPH.reset_all()
 
-    let res_0 = SUM.forward[axis=0](t1)
+    var res_0 = SUM.forward[axis=0](t1)
 
     expected = Tensor[dtype](1, 3)
     fill[dtype, nelts](expected, 2.0)
@@ -180,7 +180,7 @@ fn test_SUM() raises:
     assert_equal(GRAPH.graph.size, 2)
     GRAPH.reset_all()
 
-    let res_1 = SUM.forward[axis=1](t1)
+    var res_1 = SUM.forward[axis=1](t1)
 
     expected = Tensor[dtype](2, 1)
     fill[dtype, nelts](expected, 3.0)
@@ -195,7 +195,7 @@ fn test_MAX() raises:
     for i in range(12):
         t[i] = i + 1
 
-    let tensor_max = MAX.forward(t)
+    var tensor_max = MAX.forward(t)
     var expected = Tensor[dtype](1)
     fill[dtype, nelts](expected, 12)
     assert_tensors_equal(tensor_max.tensor, expected)
@@ -207,7 +207,7 @@ fn test_MAX() raises:
         for i in range(tensor.num_elements()):
             tensor[i] = values[i]
 
-    let tensor_max_axis_0 = MAX.forward[axis=0](t)
+    var tensor_max_axis_0 = MAX.forward[axis=0](t)
     var expected_max_axis_0_temp = StaticIntTuple[6](7, 8, 9, 10, 11, 12)
     expected = Tensor[dtype](1, 3, 2)
     fill_tensor(expected, expected_max_axis_0_temp)
@@ -215,7 +215,7 @@ fn test_MAX() raises:
     assert_equal(GRAPH.graph.size, 2)
     GRAPH.reset_all()
 
-    let tensor_max_axis_1 = MAX.forward[axis=1](t)
+    var tensor_max_axis_1 = MAX.forward[axis=1](t)
     var expected_max_axis_1_temp = StaticIntTuple[4](5, 6, 11, 12)
     expected = Tensor[dtype](2, 1, 2)
     fill_tensor(expected, expected_max_axis_1_temp)
@@ -233,7 +233,7 @@ fn test_TRANSPOSE() raises:
         B[2 * i] = i + 1
         B[2 * i + 1] = i + 4
 
-    let res = TRANSPOSE.forward(A)
+    var res = TRANSPOSE.forward(A)
 
     assert_tensors_equal(res.tensor, B)
     assert_equal(GRAPH.graph.size, 2)
@@ -248,7 +248,7 @@ fn test_FLATTEN() raises:
         A[i] = i + 1
         B[i] = i + 1
 
-    let res = FLATTEN.forward(A)
+    var res = FLATTEN.forward(A)
 
     assert_tensors_equal(res.tensor, B)
     assert_equal(GRAPH.graph.size, 2)
@@ -258,14 +258,14 @@ fn test_FLATTEN() raises:
 # <------------RESHAPE------------>
 fn test_RESHAPE() raises:
     var A = Tensor[dtype](2, 2, 5)
-    let new_shape = TensorShape(2, 10)
+    var new_shape = TensorShape(2, 10)
 
     var B = Tensor[dtype](new_shape)
     for i in range(20):
         A[i] = i + 1
         B[i] = i + 1
 
-    let res = RESHAPE.forward(A, new_shape)
+    var res = RESHAPE.forward(A, new_shape)
 
     assert_tensors_equal(res.tensor, B)
     assert_equal(GRAPH.graph.size, 2)

--- a/test/test_pool.mojo
+++ b/test/test_pool.mojo
@@ -26,16 +26,16 @@ fn torch_maxpool2d(
     dilation: StaticIntTuple[2],
     upper_grad: Tensor
 ) -> torch_maxpool2d_output:
-    let out: torch_maxpool2d_output
+    var out: torch_maxpool2d_output
     
     try:
-        let torch = Python.import_module("torch")
-        let F = Python.import_module("torch.nn.functional")
-        let np = Python.import_module("numpy")
+        var torch = Python.import_module("torch")
+        var F = Python.import_module("torch.nn.functional")
+        var np = Python.import_module("numpy")
 
-        let inputs = torch.from_numpy(to_numpy(inputs)).requires_grad_(True)
+        var inputs = torch.from_numpy(to_numpy(inputs)).requires_grad_(True)
 
-        let expected = F.max_pool2d(
+        var expected = F.max_pool2d(
             inputs,
             (kernel_size[0], kernel_size[1]),
             (stride[0], stride[1]),
@@ -44,7 +44,7 @@ fn torch_maxpool2d(
         )
 
         # uppergrad & backwards
-        let upper_grad = torch.from_numpy(to_numpy(upper_grad))
+        var upper_grad = torch.from_numpy(to_numpy(upper_grad))
         _ = expected.backward(upper_grad)
 
         # expected
@@ -56,8 +56,8 @@ fn torch_maxpool2d(
 
     except:
         print("Error in torch_maxpool2d")
-        let d = Tensor[dtype](1)
-        let out = torch_maxpool2d_output(d, d)
+        var d = Tensor[dtype](1)
+        var out = torch_maxpool2d_output(d, d)
         return out
 
 
@@ -68,10 +68,10 @@ fn test_forward_1() raises:
     alias padding = 2
     alias stride = 1
     alias dilation = 1
-    let inputs = rand[dtype](4, 1, 28, 28)
+    var inputs = rand[dtype](4, 1, 28, 28)
 
-    let res = MAXPOOL2D.forward[kernel_size, stride, padding, dilation](inputs)
-    let torch_out = torch_maxpool2d(
+    var res = MAXPOOL2D.forward[kernel_size, stride, padding, dilation](inputs)
+    var torch_out = torch_maxpool2d(
         inputs,
         kernel_size,
         padding=padding,
@@ -90,10 +90,10 @@ fn test_forward_2() raises:
     alias padding = 0
     alias stride = 1
     alias dilation = 1
-    let inputs = rand[dtype](4, 1, 32, 17)
+    var inputs = rand[dtype](4, 1, 32, 17)
     
-    let res = MAXPOOL2D.forward[kernel_size, stride, padding, dilation](inputs)
-    let torch_out = torch_maxpool2d(
+    var res = MAXPOOL2D.forward[kernel_size, stride, padding, dilation](inputs)
+    var torch_out = torch_maxpool2d(
         inputs,
         kernel_size,
         padding=padding,
@@ -116,8 +116,8 @@ fn test_forward_3() raises:
     var inputs = Tensor[dtype](4, 3, 32, 17)
     fill[dtype, nelts](inputs, 1.0)
 
-    let res = MAXPOOL2D.forward[kernel_size, stride, padding, dilation](inputs)
-    let torch_out = torch_maxpool2d(
+    var res = MAXPOOL2D.forward[kernel_size, stride, padding, dilation](inputs)
+    var torch_out = torch_maxpool2d(
         inputs,
         kernel_size,
         padding=padding,
@@ -136,16 +136,16 @@ fn test_backward_1() raises:
     alias padding = 2
     alias stride = 1
     alias dilation = 1
-    let inputs = rand[dtype](4, 1, 28, 28)
+    var inputs = rand[dtype](4, 1, 28, 28)
     
-    let res = MAXPOOL2D.forward[kernel_size, stride, padding, dilation](inputs)
+    var res = MAXPOOL2D.forward[kernel_size, stride, padding, dilation](inputs)
     
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 1)
-    let upper_grad: Tensor[dtype] = rand[dtype](res.tensor.shape())
+    var upper_grad: Tensor[dtype] = rand[dtype](res.tensor.shape())
     
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0) # inputs.grad
-    let torch_out = torch_maxpool2d(
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0) # inputs.grad
+    var torch_out = torch_maxpool2d(
         inputs,
         kernel_size,
         padding=padding,
@@ -165,16 +165,16 @@ fn test_backward_2() raises:
     alias padding = 0
     alias stride = 1
     alias dilation = 1
-    let inputs = rand[dtype](4, 1, 32, 17)
+    var inputs = rand[dtype](4, 1, 32, 17)
 
-    let res = MAXPOOL2D.forward[kernel_size, stride, padding, dilation](inputs)
+    var res = MAXPOOL2D.forward[kernel_size, stride, padding, dilation](inputs)
     
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 1)
-    let upper_grad: Tensor[dtype] = rand[dtype](res.tensor.shape())
+    var upper_grad: Tensor[dtype] = rand[dtype](res.tensor.shape())
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0) # inputs.grad
-    let torch_out = torch_maxpool2d(
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0) # inputs.grad
+    var torch_out = torch_maxpool2d(
         inputs,
         kernel_size,
         padding=padding,
@@ -197,14 +197,14 @@ fn test_backward_3() raises:
     var inputs = Tensor[dtype](4, 3, 32, 17)
     fill[dtype, nelts](inputs, 1.0)
 
-    let res = MAXPOOL2D.forward[kernel_size, stride, padding, dilation](inputs)
+    var res = MAXPOOL2D.forward[kernel_size, stride, padding, dilation](inputs)
     
-    let gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
+    var gn = GRAPH.graph[GRAPH.get_node_idx(res.uuid)]
     assert_equal(gn.parents.size, 1)
-    let upper_grad: Tensor[dtype] = rand[dtype](res.tensor.shape())
+    var upper_grad: Tensor[dtype] = rand[dtype](res.tensor.shape())
 
-    let ug1 = gn.backward_fn(upper_grad, gn.parents, 0) # inputs.grad
-    let torch_out = torch_maxpool2d(
+    var ug1 = gn.backward_fn(upper_grad, gn.parents, 0) # inputs.grad
+    var torch_out = torch_maxpool2d(
         inputs,
         kernel_size,
         padding=padding,

--- a/test/test_regression.mojo
+++ b/test/test_regression.mojo
@@ -19,8 +19,8 @@ struct LinearRegression:
 
 
 fn main():    
-    let batch_size = 4
-    let input_size = 13
+    var batch_size = 4
+    var input_size = 13
 
     var model = LinearRegression(input_size)
     var loss_func = nn.MSELoss()
@@ -34,7 +34,7 @@ fn main():
 
     #### FORWARD ####
     optim.zero_grad()
-    let output = model.forward(batch_data)
+    var output = model.forward(batch_data)
     var loss = loss_func(output, batch_labels)
     # print("OUTPUT: ", output.tensor)
     print("LOSS: ", loss.tensor[0])
@@ -65,7 +65,7 @@ fn main():
     #### FORWARD2 ####
     print("------------ SECOND ITER ------------")
     optim.zero_grad()
-    let output2 = model.forward(batch_data)
+    var output2 = model.forward(batch_data)
     var loss2 = loss_func(output2, batch_labels)
     # print("OUTPUT: ", output2.tensor)
     print("LOSS: ", loss2.tensor[0])

--- a/test/test_tensorutils.mojo
+++ b/test/test_tensorutils.mojo
@@ -36,7 +36,7 @@ fn assert_tensors_equal(t1: Tensor[dtype], t2: Tensor[dtype], mode: String = "ex
 
 # <------------ZERO------------>
 fn test_zero() raises:
-    let A = Tensor[dtype](2, 3)
+    var A = Tensor[dtype](2, 3)
     var B = rand[dtype](2, 3)
     zero[dtype](B)
     assert_tensors_equal(A, B)
@@ -59,12 +59,12 @@ fn test_dot() raises:
     fill[dtype, nelts](A, 1.0)
     fill[dtype, nelts](B, 1.0)
 
-    let C = dot[dtype, nelts](A, B)
+    var C = dot[dtype, nelts](A, B)
     var C_expected = Tensor[dtype](2, 2)
     fill[dtype, nelts](C_expected, 3.0)
     assert_tensors_equal(C, C_expected)
 
-    let D = dot[dtype, nelts](B, A)
+    var D = dot[dtype, nelts](B, A)
     var D_expected = Tensor[dtype](3, 3)
     fill[dtype, nelts](D_expected, 2.0)
     assert_tensors_equal(D, D_expected)
@@ -99,7 +99,7 @@ fn test_elwise_pow() raises:
         A[i] = i
         B[i] = i**2
 
-    let C = elwise_pow[dtype, nelts](A, 2)
+    var C = elwise_pow[dtype, nelts](A, 2)
     assert_tensors_equal(B, C)
 
 
@@ -110,21 +110,21 @@ fn test_elwise_tensor_tensor() raises:
     fill[dtype, nelts](t1, 3.0)
     fill[dtype, nelts](t2, 3.0)
 
-    let result1 = elwise_op[dtype, nelts, add](t1, t2)
+    var result1 = elwise_op[dtype, nelts, add](t1, t2)
     var result1_expected = Tensor[dtype](2, 10)
     fill[dtype, nelts](result1_expected, 6.0)
     assert_tensors_equal(result1, result1_expected)
 
-    let result2 = elwise_op[dtype, nelts, sub](t1, t2)
-    let result2_expected = Tensor[dtype](2, 10)
+    var result2 = elwise_op[dtype, nelts, sub](t1, t2)
+    var result2_expected = Tensor[dtype](2, 10)
     assert_tensors_equal(result2, result2_expected)
 
-    let result3 = elwise_op[dtype, nelts, mul](t1, t2)
+    var result3 = elwise_op[dtype, nelts, mul](t1, t2)
     var result3_expected = Tensor[dtype](2, 10)
     fill[dtype, nelts](result3_expected, 9.0)
     assert_tensors_equal(result3, result3_expected)
 
-    let result4 = elwise_op[dtype, nelts, div](t1, t2)
+    var result4 = elwise_op[dtype, nelts, div](t1, t2)
     var result4_expected = Tensor[dtype](2, 10)
     fill[dtype, nelts](result4_expected, 1.0)
     assert_tensors_equal(result4, result4_expected)
@@ -132,29 +132,29 @@ fn test_elwise_tensor_tensor() raises:
 
 # <-------------ELEMENT WISE TESNOR-SCALAR OPERATORS------------->
 fn test_elwise_tensor_scalar() raises:
-    let a: SIMD[dtype, 1] = 2.0
+    var a: SIMD[dtype, 1] = 2.0
     var t1 = Tensor[dtype](2, 10)
     fill[dtype, nelts](t1, 1.0)
 
-    let result1 = elwise_op[dtype, nelts, add](t1, a)
+    var result1 = elwise_op[dtype, nelts, add](t1, a)
     var result1_expected = Tensor[dtype](2, 10)
     fill[dtype, nelts](result1_expected, 3.0)
     assert_tensors_equal(result1, result1_expected)
 
-    let result2 = elwise_op[dtype, nelts, add](a, t1)
+    var result2 = elwise_op[dtype, nelts, add](a, t1)
     assert_tensors_equal(result2, result1_expected)
 
-    let result3 = elwise_op[dtype, nelts, sub](t1, a)
+    var result3 = elwise_op[dtype, nelts, sub](t1, a)
     var result3_expected = Tensor[dtype](2, 10)
     fill[dtype, nelts](result3_expected, -1)
     assert_tensors_equal(result3, result3_expected)
 
-    let result4 = elwise_op[dtype, nelts, mul](a, t1)
+    var result4 = elwise_op[dtype, nelts, mul](a, t1)
     var result4_expected = Tensor[dtype](2, 10)
     fill[dtype, nelts](result4_expected, 2)
     assert_tensors_equal(result4, result4_expected)
 
-    let result5 = elwise_op[dtype, nelts, div](t1, a)
+    var result5 = elwise_op[dtype, nelts, div](t1, a)
     var result5_expected = Tensor[dtype](2, 10)
     fill[dtype, nelts](result5_expected, 0.5)
     assert_tensors_equal(result5, result5_expected)
@@ -168,12 +168,12 @@ fn test_elwise_broadcast_tensor() raises:
     for i in range(40):
         t2[i] = i + 1
 
-    let result1 = broadcast_elwise_op[dtype, nelts, add](t1, t2)
+    var result1 = broadcast_elwise_op[dtype, nelts, add](t1, t2)
     var result1_expected = Tensor[dtype](5, 2, 3, 4)
     # fill expected tensor
     for i in range(40):
         for j in range(3):
-            let index = (i % 4) + ((i // 4) * 12) + j * 4
+            var index = (i % 4) + ((i // 4) * 12) + j * 4
             result1_expected[index] = 3.0 + (i + 1)
     assert_tensors_equal(result1, result1_expected)
 
@@ -189,13 +189,13 @@ fn test_sum_mean_std() raises:
         s += i + 1
 
     # Not specifying the axis takes all elements regardless of the shape
-    let tensor_sum = tsum[dtype, nelts](t)
+    var tensor_sum = tsum[dtype, nelts](t)
     assert_equal(tensor_sum, s)
 
-    let tensor_mean = tmean[dtype, nelts](t)
+    var tensor_mean = tmean[dtype, nelts](t)
     assert_equal(tensor_mean, s / 20)
 
-    let tensor_std = tstd[dtype, nelts](t)
+    var tensor_std = tstd[dtype, nelts](t)
     var expected_std: SIMD[dtype, 1] = 0
     for i in range(20):
         expected_std += (i + 1 - tensor_mean) ** 2
@@ -204,37 +204,37 @@ fn test_sum_mean_std() raises:
 
     # When specifying the axis you can sum across batches
     # Axis 0
-    let batch_sum_0 = tsum[dtype, nelts](t, axis=0)
+    var batch_sum_0 = tsum[dtype, nelts](t, axis=0)
     var expected_batch_sum_0 = Tensor[dtype](1, 10)
     for i in range(10):
         expected_batch_sum_0[i] = (i + 1) + (i + 1 + 10)
     assert_tensors_equal(batch_sum_0, expected_batch_sum_0)
 
-    let batch_mean_0 = tmean[dtype, nelts](t, axis=0)
+    var batch_mean_0 = tmean[dtype, nelts](t, axis=0)
     var expected_batch_mean_0 = Tensor[dtype](1, 10)
     for i in range(10):
         expected_batch_mean_0[i] = expected_batch_sum_0[i] / 2
     assert_tensors_equal(batch_mean_0, expected_batch_mean_0)
 
-    let batch_std_0 = tstd[dtype, nelts](t, axis=0)
+    var batch_std_0 = tstd[dtype, nelts](t, axis=0)
     var expected_batch_std_0 = Tensor[dtype](1, 10)
     fill[dtype, nelts](expected_batch_std_0, 5)
     assert_tensors_equal(batch_std_0, expected_batch_std_0)
 
     # Axis 1
-    let batch_sum_1 = tsum[dtype, nelts](t, axis=1)
+    var batch_sum_1 = tsum[dtype, nelts](t, axis=1)
     var expected_batch_sum_1 = Tensor[dtype](2, 1)
     expected_batch_sum_1[0] = 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10
     expected_batch_sum_1[1] = 11 + 12 + 13 + 14 + 15 + 16 + 17 + 18 + 19 + 20
     assert_tensors_equal(batch_sum_1, expected_batch_sum_1)
 
-    let batch_mean_1 = tmean[dtype, nelts](t, axis=1)
+    var batch_mean_1 = tmean[dtype, nelts](t, axis=1)
     var expected_batch_mean_1 = Tensor[dtype](2, 1)
     expected_batch_mean_1[0] = expected_batch_sum_1[0] / 10
     expected_batch_mean_1[1] = expected_batch_sum_1[1] / 10
     assert_tensors_equal(batch_mean_1, expected_batch_mean_1)
 
-    let batch_std_1 = tstd[dtype, nelts](t, axis=1)
+    var batch_std_1 = tstd[dtype, nelts](t, axis=1)
     var expected_batch_std_1 = Tensor[dtype](2, 1)
     fill[dtype, nelts](expected_batch_std_1, 2.8722813129425049)
     assert_tensors_equal(batch_std_1, expected_batch_std_1)
@@ -247,13 +247,13 @@ fn test_sum_mean_std_n() raises:
         s += i + 1
 
     # Not specifying the axis takes all elements regardless of the shape
-    let tensor_sum = tsum[dtype, nelts](t)
+    var tensor_sum = tsum[dtype, nelts](t)
     assert_equal(tensor_sum, s)
 
-    let tensor_mean = tmean[dtype, nelts](t)
+    var tensor_mean = tmean[dtype, nelts](t)
     assert_equal(tensor_mean, s / 60)
 
-    let tensor_std = tstd[dtype, nelts](t)
+    var tensor_std = tstd[dtype, nelts](t)
     var expected_std: SIMD[dtype, 1] = 0
     for i in range(60):
         expected_std += (i + 1 - tensor_mean) ** 2
@@ -263,37 +263,37 @@ fn test_sum_mean_std_n() raises:
     # When specifying the axis you can sum across batches
     # Axis 0
     var data = SumMeanStdData.generate_3d_axis_0()
-    let batch_sum_0 = tsum[dtype, nelts](t, axis=0)
+    var batch_sum_0 = tsum[dtype, nelts](t, axis=0)
     assert_tensors_equal(batch_sum_0, data.expected_sum)
 
-    let batch_mean_0 = tmean[dtype, nelts](t, axis=0)
+    var batch_mean_0 = tmean[dtype, nelts](t, axis=0)
     assert_tensors_equal(batch_mean_0, data.expected_mean)
 
-    let batch_std_0 = tstd[dtype, nelts](t, axis=0)
+    var batch_std_0 = tstd[dtype, nelts](t, axis=0)
     assert_tensors_equal(batch_std_0, data.expected_std)
 
     # When specifying the axis you can sum across batches
     # Axis 1
     data = SumMeanStdData.generate_3d_axis_1()
-    let batch_sum_1 = tsum[dtype, nelts](t, axis=1)
+    var batch_sum_1 = tsum[dtype, nelts](t, axis=1)
     assert_tensors_equal(batch_sum_1, data.expected_sum)
 
-    let batch_mean_1 = tmean[dtype, nelts](t, axis=1)
+    var batch_mean_1 = tmean[dtype, nelts](t, axis=1)
     assert_tensors_equal(batch_mean_1, data.expected_mean)
 
-    let batch_std_1 = tstd[dtype, nelts](t, axis=1)
+    var batch_std_1 = tstd[dtype, nelts](t, axis=1)
     assert_tensors_equal(batch_std_1, data.expected_std)
 
     # When specifying the axis you can sum across batches
     # Axis 2
     data = SumMeanStdData.generate_3d_axis_2()
-    let batch_sum_2 = tsum[dtype, nelts](t, axis=2)
+    var batch_sum_2 = tsum[dtype, nelts](t, axis=2)
     assert_tensors_equal(batch_sum_2, data.expected_sum)
 
-    let batch_mean_2 = tmean[dtype, nelts](t, axis=2)
+    var batch_mean_2 = tmean[dtype, nelts](t, axis=2)
     assert_tensors_equal(batch_mean_2, data.expected_mean)
 
-    let batch_std_2 = tstd[dtype, nelts](t, axis=2)
+    var batch_std_2 = tstd[dtype, nelts](t, axis=2)
     assert_tensors_equal(batch_std_2, data.expected_std)
 
 
@@ -303,7 +303,7 @@ fn test_max() raises:
     for i in range(12):
         t[i] = i + 1
 
-    let tensor_max = tmax[dtype, nelts](t)
+    var tensor_max = tmax[dtype, nelts](t)
     assert_equal(tensor_max, 12)
 
     @parameter
@@ -311,19 +311,19 @@ fn test_max() raises:
         for i in range(tensor.num_elements()):
             tensor[i] = values[i]
 
-    let tensor_max_axis_0 = tmax[dtype, nelts](t, axis=0)
+    var tensor_max_axis_0 = tmax[dtype, nelts](t, axis=0)
     var expected_max_axis_0_temp = StaticIntTuple[6](7, 8, 9, 10, 11, 12)
     var expected_max_axis_0 = Tensor[dtype](1, 3, 2)
     fill_tensor(expected_max_axis_0, expected_max_axis_0_temp)
     assert_tensors_equal(tensor_max_axis_0, expected_max_axis_0)
 
-    let tensor_max_axis_1 = tmax[dtype, nelts](t, axis=1)
+    var tensor_max_axis_1 = tmax[dtype, nelts](t, axis=1)
     var expected_max_axis_1_temp = StaticIntTuple[4](5, 6, 11, 12)
     var expected_max_axis_1 = Tensor[dtype](2, 1, 2)
     fill_tensor(expected_max_axis_1, expected_max_axis_1_temp)
     assert_tensors_equal(tensor_max_axis_1, expected_max_axis_1)
 
-    let tensor_max_axis_2 = tmax[dtype, nelts](t, axis=2)
+    var tensor_max_axis_2 = tmax[dtype, nelts](t, axis=2)
     var expected_max_axis_2_temp = StaticIntTuple[6](2, 4, 6, 8, 10, 12)
     var expected_max_axis_2 = Tensor[dtype](2, 3, 1)
     fill_tensor(expected_max_axis_2, expected_max_axis_2_temp)
@@ -387,7 +387,7 @@ fn test_flatten() raises:
     )  # or A.ireshape to modify in place
     assert_tensors_equal(A_flat, B)
 
-    let A_resh = A_flat.reshape(A.shape())  # or A_flat.ireshape to modify in place
+    var A_resh = A_flat.reshape(A.shape())  # or A_flat.ireshape to modify in place
     assert_tensors_equal(A_resh, A)
 
 

--- a/test/test_tensorutils_data.mojo
+++ b/test/test_tensorutils_data.mojo
@@ -7,7 +7,7 @@ alias nelts = simdwidthof[dtype]()
 
 fn generate_tensor(*shape: Int) -> Tensor[dtype]:
     var A = Tensor[dtype](shape)
-    let size = A.num_elements()
+    var size = A.num_elements()
     for i in range(size):
         A[i] = i + 1
     return A ^
@@ -34,37 +34,37 @@ struct TransposeData:
 
     @staticmethod
     fn generate_1_2dim_test_case() -> TransposeData:
-        let A = generate_tensor(2, 3)
-        let expected = StaticIntTuple[6](1, 4, 2, 5, 3, 6)
-        let tranpose_dims = VariadicList[Int](0, 1)
-        let B = generate_expected_tensor(expected, 3, 2)
+        var A = generate_tensor(2, 3)
+        var expected = StaticIntTuple[6](1, 4, 2, 5, 3, 6)
+        var tranpose_dims = VariadicList[Int](0, 1)
+        var B = generate_expected_tensor(expected, 3, 2)
 
         return TransposeData(A, B, tranpose_dims)
 
     @staticmethod
     fn generate_2_2dim_test_case() -> TransposeData:
-        let A = generate_tensor(2, 3, 2)
-        let expected = StaticIntTuple[12](1, 7, 3, 9, 5, 11, 2, 8, 4, 10, 6, 12)
-        let tranpose_dims = VariadicList[Int](0, 2)
-        let B = generate_expected_tensor(expected, 2, 3, 2)
+        var A = generate_tensor(2, 3, 2)
+        var expected = StaticIntTuple[12](1, 7, 3, 9, 5, 11, 2, 8, 4, 10, 6, 12)
+        var tranpose_dims = VariadicList[Int](0, 2)
+        var B = generate_expected_tensor(expected, 2, 3, 2)
 
         return TransposeData(A, B, tranpose_dims)
 
     @staticmethod
     fn generate_3_2dim_test_case() -> TransposeData:
-        let A = generate_tensor(2, 3, 2, 3)
-        let expected = StaticIntTuple[36](1, 2, 3, 7, 8, 9, 13, 14, 15, 4, 5, 6, 
+        var A = generate_tensor(2, 3, 2, 3)
+        var expected = StaticIntTuple[36](1, 2, 3, 7, 8, 9, 13, 14, 15, 4, 5, 6, 
         10, 11, 12, 16, 17, 18, 19, 20, 21, 25, 26, 27, 31, 32, 33, 22, 23, 24, 
         28, 29, 30, 34, 35, 36)
-        let tranpose_dims = VariadicList[Int](1, 2)
-        let B = generate_expected_tensor(expected, 2, 2, 3, 3)
+        var tranpose_dims = VariadicList[Int](1, 2)
+        var B = generate_expected_tensor(expected, 2, 2, 3, 3)
 
         return TransposeData(A, B, tranpose_dims)
 
     @staticmethod
     fn generate_4_2dim_test_case() -> TransposeData:
-        let A = generate_tensor(3, 2, 3, 2, 3)
-        let expected = StaticIntTuple[108](1, 2, 3, 19, 20, 21, 7, 8, 9, 25, 
+        var A = generate_tensor(3, 2, 3, 2, 3)
+        var expected = StaticIntTuple[108](1, 2, 3, 19, 20, 21, 7, 8, 9, 25, 
         26, 27, 13, 14, 15, 31, 32, 33, 4, 5, 6, 22, 23, 24, 10, 11, 12, 28, 
         29, 30, 16, 17, 18, 34, 35, 36, 37, 38, 39, 55, 56, 57, 43, 44, 45, 61, 
         62, 63, 49, 50, 51, 67, 68, 69, 40, 41, 42, 58, 59, 60, 46, 47, 48, 64, 
@@ -72,28 +72,28 @@ struct TransposeData:
         98, 99, 85, 86, 87, 103, 104, 105, 76, 77, 78, 94, 95, 96, 82, 83, 84, 
         100, 101, 102, 88, 89, 90, 106, 107, 108
         )
-        let tranpose_dims = VariadicList[Int](1, 3)
-        let B = generate_expected_tensor(expected, 3, 2, 3, 2, 3)
+        var tranpose_dims = VariadicList[Int](1, 3)
+        var B = generate_expected_tensor(expected, 3, 2, 3, 2, 3)
 
         return TransposeData(A, B, tranpose_dims)
 
     @staticmethod
     fn generate_1_alldim_test_case() -> TransposeData:
-        let A = generate_tensor(2, 3, 2, 3)
-        let expected = StaticIntTuple[36](1,4,2,5,3,6,19,22,20,23,21,24,7,10,8,
+        var A = generate_tensor(2, 3, 2, 3)
+        var expected = StaticIntTuple[36](1,4,2,5,3,6,19,22,20,23,21,24,7,10,8,
         11,9,12,25,28,26,29,27,30,13,16,14,17,15,18,31,34,32,35,33,36)
-        let tranpose_dims = VariadicList[Int](1, 0, 3, 2)
-        let B = generate_expected_tensor(expected, 3, 2, 3, 2)
+        var tranpose_dims = VariadicList[Int](1, 0, 3, 2)
+        var B = generate_expected_tensor(expected, 3, 2, 3, 2)
 
         return TransposeData(A, B, tranpose_dims)
 
     @staticmethod
     fn generate_1_transpose_test_case() -> TransposeData:
-        let A = generate_tensor(2, 3, 2, 3)
-        let expected = StaticIntTuple[36](1,19,7,25,13,31,4,22,10,28,16,34,2,20,
+        var A = generate_tensor(2, 3, 2, 3)
+        var expected = StaticIntTuple[36](1,19,7,25,13,31,4,22,10,28,16,34,2,20,
         8,26,14,32,5,23,11,29,17,35,3,21,9,27,15,33,6,24,12,30,18,36)
-        let tranpose_dims = VariadicList[Int](3, 2, 1, 0)
-        let B = generate_expected_tensor(expected, 3, 2, 3, 2)
+        var tranpose_dims = VariadicList[Int](3, 2, 1, 0)
+        var B = generate_expected_tensor(expected, 3, 2, 3, 2)
 
         return TransposeData(A, B, tranpose_dims)
 
@@ -110,35 +110,35 @@ struct PaddingData:
 
     @staticmethod
     fn generate_1d_test_case_after() -> PaddingData:
-        let A = generate_tensor(2)
+        var A = generate_tensor(2)
 
-        let expected = StaticIntTuple[4](1, 2, 0, 0)
+        var expected = StaticIntTuple[4](1, 2, 0, 0)
         var pad_with = DynamicVector[Int]()
         pad_with.push_back(0) # before
         pad_with.push_back(2) # after
 
-        let B = generate_expected_tensor(expected, 4)
+        var B = generate_expected_tensor(expected, 4)
 
         return PaddingData(A, B, pad_with)
 
     @staticmethod
     fn generate_1d_test_case_before_after() -> PaddingData:
-        let A = generate_tensor(3)
+        var A = generate_tensor(3)
 
-        let expected = StaticIntTuple[6](0, 0, 1, 2, 3, 0)
+        var expected = StaticIntTuple[6](0, 0, 1, 2, 3, 0)
         var pad_with = DynamicVector[Int]()
         pad_with.push_back(2) # before
         pad_with.push_back(1) # after
 
-        let B = generate_expected_tensor(expected, 6)
+        var B = generate_expected_tensor(expected, 6)
 
         return PaddingData(A, B, pad_with)
 
     @staticmethod
     fn generate_2d_test_case() -> PaddingData:
-        let A = generate_tensor(2, 2)
+        var A = generate_tensor(2, 2)
 
-        let expected = StaticTuple[45](
+        var expected = StaticTuple[45](
             0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 1, 2, 0, 0, 0, 0,
             0, 0, 0, 3, 4, 0, 0, 0, 0,
@@ -151,15 +151,15 @@ struct PaddingData:
         pad_with.push_back(3) # before_2
         pad_with.push_back(4) # after_2
 
-        let B = generate_expected_tensor[45](expected, 5, 9)
+        var B = generate_expected_tensor[45](expected, 5, 9)
 
         return PaddingData(A, B, pad_with)
 
     @staticmethod
     fn generate_3d_test_case_simple() -> PaddingData:
-        let A = generate_tensor(2, 2, 2)
+        var A = generate_tensor(2, 2, 2)
 
-        let expected = StaticIntTuple[16](
+        var expected = StaticIntTuple[16](
             0, 0, 1, 2, 3, 4, 0, 0,
             0, 0, 5, 6, 7, 8, 0, 0
         )
@@ -171,15 +171,15 @@ struct PaddingData:
         pad_with.push_back(0) # before_3
         pad_with.push_back(0) # after_3
 
-        let B = generate_expected_tensor[16](expected, 2, 4, 2)
+        var B = generate_expected_tensor[16](expected, 2, 4, 2)
 
         return PaddingData(A, B, pad_with)
 
     @staticmethod
     fn generate_3d_test_case() -> PaddingData:
-        let A = generate_tensor(1, 2, 3)
+        var A = generate_tensor(1, 2, 3)
 
-        let expected = StaticIntTuple[45](
+        var expected = StaticIntTuple[45](
             0, 0, 0, 0, 0,
             0, 0, 0, 0, 0,
             0, 0, 0, 0, 0,
@@ -198,16 +198,16 @@ struct PaddingData:
         pad_with.push_back(0) # before_3
         pad_with.push_back(2) # after_3
 
-        let B = generate_expected_tensor[45](expected, 3, 3, 5)
+        var B = generate_expected_tensor[45](expected, 3, 3, 5)
 
         return PaddingData(A, B, pad_with)
 
     
     @staticmethod
     fn generate_4d_test_case() -> PaddingData:
-        let A = generate_tensor(2, 2, 2, 2)
+        var A = generate_tensor(2, 2, 2, 2)
 
-        let expected = StaticIntTuple[81](
+        var expected = StaticIntTuple[81](
             1,  2,  0,  3,  4,  0,  0,  0,  0,
             5,  6,  0,  7,  8,  0,  0,  0,  0,
             0,  0,  0,  0,  0,  0,  0,  0,  0,
@@ -229,7 +229,7 @@ struct PaddingData:
         pad_with.push_back(0) # before_4
         pad_with.push_back(1) # after_4
 
-        let B = generate_expected_tensor[81](expected, 3, 3, 3, 3)
+        var B = generate_expected_tensor[81](expected, 3, 3, 3, 3)
 
         return PaddingData(A, B, pad_with)
 
@@ -252,17 +252,17 @@ struct SumMeanStdData:
         
     @staticmethod
     fn generate_3d_axis_0() -> SumMeanStdData:
-        let A = generate_tensor(3, 4, 5)
-        let axis = 0
+        var A = generate_tensor(3, 4, 5)
+        var axis = 0
 
-        let expected_sum = StaticIntTuple[20](
+        var expected_sum = StaticIntTuple[20](
             63,  66,  69,  72,  75,
             78,  81,  84,  87,  90,
             93,  96,  99,  102, 105,
             108, 111, 114, 117, 120,
         )
 
-        let expected_mean = StaticIntTuple[20](
+        var expected_mean = StaticIntTuple[20](
             21, 22, 23, 24, 25,
             26, 27, 28, 29, 30,
             31, 32, 33, 34, 35,
@@ -272,23 +272,23 @@ struct SumMeanStdData:
         var expected_std = Tensor[dtype](1, 4, 5)
         fill[dtype, nelts](expected_std, 16.32993162)
         
-        let B = generate_expected_tensor[20](expected_sum, 1, 4, 5)
-        let C = generate_expected_tensor[20](expected_mean, 1, 4, 5)
+        var B = generate_expected_tensor[20](expected_sum, 1, 4, 5)
+        var C = generate_expected_tensor[20](expected_mean, 1, 4, 5)
 
         return SumMeanStdData(A, axis, B, C, expected_std)
 
     @staticmethod
     fn generate_3d_axis_1() -> SumMeanStdData:
-        let A = generate_tensor(3, 4, 5)
-        let axis = 1
+        var A = generate_tensor(3, 4, 5)
+        var axis = 1
 
-        let expected_sum = StaticIntTuple[15](
+        var expected_sum = StaticIntTuple[15](
             34,  38,  42,  46,  50,
             114, 118, 122, 126, 130,
             194, 198, 202, 206, 210,
         )
 
-        let expected_mean = StaticIntTuple[15](
+        var expected_mean = StaticIntTuple[15](
             8,  9,  10, 11, 12,
             28, 29, 30, 31, 32,
             48, 49, 50, 51, 52,
@@ -297,7 +297,7 @@ struct SumMeanStdData:
         var expected_std = Tensor[dtype](3, 1, 5)
         fill[dtype, nelts](expected_std, 5.59016994)
 
-        let B = generate_expected_tensor[15](expected_sum, 3, 1, 5)
+        var B = generate_expected_tensor[15](expected_sum, 3, 1, 5)
         var C = generate_expected_tensor[15](expected_mean, 3, 1, 5)
         C = elwise_op[dtype, nelts, add](C, 0.5)
 
@@ -305,16 +305,16 @@ struct SumMeanStdData:
 
     @staticmethod
     fn generate_3d_axis_2() -> SumMeanStdData:
-        let A = generate_tensor(3, 4, 5)
-        let axis = 2
+        var A = generate_tensor(3, 4, 5)
+        var axis = 2
 
-        let expected_sum = StaticIntTuple[12](
+        var expected_sum = StaticIntTuple[12](
             15,  40,  65,  90,
             115, 140, 165, 190,
             215, 240, 265, 290,
         )
 
-        let expected_mean = StaticIntTuple[12](
+        var expected_mean = StaticIntTuple[12](
             3,  8,  13, 18,
             23, 28, 33, 38,
             43, 48, 53, 58,
@@ -323,7 +323,7 @@ struct SumMeanStdData:
         var expected_std = Tensor[dtype](3, 4, 1)
         fill[dtype, nelts](expected_std, 1.41421356)
 
-        let B = generate_expected_tensor[12](expected_sum, 3, 4, 1)
-        let C = generate_expected_tensor[12](expected_mean, 3, 4, 1)
+        var B = generate_expected_tensor[12](expected_sum, 3, 4, 1)
+        var C = generate_expected_tensor[12](expected_mean, 3, 4, 1)
 
         return SumMeanStdData(A, axis, B, C, expected_std)

--- a/test/test_traits.mojo
+++ b/test/test_traits.mojo
@@ -67,8 +67,8 @@ var GRAPH = Graph[dtype]()
 
 fn main():
     
-    let t0: Tensor[dtype] = rand[dtype](3, 4)
-    let t1: Tensor[dtype] = rand[dtype](1, 4)
+    var t0: Tensor[dtype] = rand[dtype](3, 4)
+    var t1: Tensor[dtype] = rand[dtype](1, 4)
 
     var mynode = Node[dtype](t0, requires_grad=True)
     var mychild = Node[dtype](t1, requires_grad=True)
@@ -77,7 +77,7 @@ fn main():
     GRAPH.add_node(mychild)
 
     for i in range(GRAPH.graph.size):
-        let n = GRAPH.graph[i]
+        var n = GRAPH.graph[i]
         print("GRAPH: ", n.uuid)
         for i in range(n.children.size):
             print("\tMYCHILD: ", n.children[i])

--- a/test/test_uuid.mojo
+++ b/test/test_uuid.mojo
@@ -3,9 +3,9 @@ from dainemo.utils.uuid import uuid
 
 
 fn test_uuid_length() raises:
-    let id = uuid()
+    var id = uuid()
 
-    let splitted = id.split("-")
+    var splitted = id.split("-")
     var char_count = 0
     for i in range(splitted.size):
         char_count += len(splitted[i])
@@ -16,22 +16,22 @@ fn test_uuid_length() raises:
 
 fn test_uuid_uniqueness() raises:
     for i in range(10):
-        let id1 = uuid()
-        let id2 = uuid()
+        var id1 = uuid()
+        var id2 = uuid()
         assert_not_equal(id1, id2)
 
 
 fn test_uuid_version() raises:
     for i in range(10):
-        let id = uuid()
+        var id = uuid()
         assert_equal(id.split("-")[2][0], '4')
 
 
 fn test_uuid_variant() raises:
     for i in range(10):
-        let id = uuid()
-        let variant = id.split("-")[3][0]
-        let variant_condition = variant == '8' or variant == '9' or variant == 'a' or variant == 'b'
+        var id = uuid()
+        var variant = id.split("-")[3][0]
+        var variant_condition = variant == '8' or variant == '9' or variant == 'a' or variant == 'b'
         assert_true(variant_condition)
 
 


### PR DESCRIPTION
- Changes `let` to `var` to fix compiler warnings
- Fix vectorize signatures
- Use keyword-only capacity